### PR TITLE
Token limitation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /state
 __pycache__/
 my_config.json
+/topic_transition_test

--- a/metrics.py
+++ b/metrics.py
@@ -28,10 +28,10 @@ class MetricsHandler:
             self._feedback_file.write_text(
                 ','.join(['timestamp', 'guild_id', 'thread_id', 'user_id', 'feedback_score']) + '\n')
 
-    async def record_message(self, guild_id: int, thread_id: int, user_id: int, message_index: int, role: str, message: str):
+    async def record_message(self, guild_id: int, thread_id: int, user_id: int, role: str, message: str):
         with self._messages_file.open('at', newline='') as file:
             writer = csv.writer(file)
-            writer.writerow([get_timestamp(), guild_id, thread_id, user_id, message_index, role, message])
+            writer.writerow([get_timestamp(), guild_id, thread_id, user_id, role, message])
 
     async def record_usage(self, guild_id, thread_id, user_id, engine, input_tokens, output_tokens):
         with self._usage_file.open('at', newline='') as file:

--- a/metrics.py
+++ b/metrics.py
@@ -28,10 +28,10 @@ class MetricsHandler:
             self._feedback_file.write_text(
                 ','.join(['timestamp', 'guild_id', 'thread_id', 'user_id', 'feedback_score']) + '\n')
 
-    async def record_message(self, guild_id: int, thread_id: int, user_id: int, role: str, message: str):
+    async def record_message(self, guild_id: int, thread_id: int, user_id: int, message_index: int, role: str, message: str):
         with self._messages_file.open('at', newline='') as file:
             writer = csv.writer(file)
-            writer.writerow([get_timestamp(), guild_id, thread_id, user_id, role, message])
+            writer.writerow([get_timestamp(), guild_id, thread_id, user_id, message_index, role, message])
 
     async def record_usage(self, guild_id, thread_id, user_id, engine, input_tokens, output_tokens):
         with self._usage_file.open('at', newline='') as file:

--- a/rubber_duck.py
+++ b/rubber_duck.py
@@ -87,17 +87,22 @@ class RubberDuck:
     #
     async def have_conversation(self, thread_id: int, engine: str, prompt: str, initial_message: Message, timeout=600):
         user_id = initial_message['author_id']
+        long_input_char = 100
 
         async with queue('messages', str(thread_id)) as messages:
-            message_history = [
-                GPTMessage(role='system', content=prompt)
-            ]
+            message_history = {
+                0: GPTMessage(role='system', content=prompt)
+            }
+
             user_id = initial_message['author_id']
             guild_id = initial_message['guild_id']
             await self._metrics_handler.record_message(
-                guild_id, thread_id, user_id, message_history[0]['role'], message_history[0]['content'])
+                guild_id, thread_id, user_id, 0, message_history[0]['role'], message_history[0]['content'])
 
             await self._send_message(thread_id, f'Hello {initial_message["author_mention"]}, how can I help you?')
+
+            latest_long_input_index = None
+            message_index = 1
 
             while True:
                 # TODO - if the conversation is getting long, and the user changes the subject
@@ -110,22 +115,31 @@ class RubberDuck:
                     await self.feedback_workflow.request_feedback(guild_id, thread_id, user_id)
                     return
 
-                message_history.append(GPTMessage(role='user', content=message['content']))
+                message_history[message_index] = GPTMessage(role='user', content=message['content'])
 
-                # After user messages has added
-                # if len(message_history) > 5:
-                #     message_history = [message_history[0]] + message_history[-4:]
+                if len(message['content']) > long_input_char:
+                    latest_long_input_index = message_index
+
+                # Message used for response
+                response_used_messages = {0: message_history[0]}
+                if latest_long_input_index:
+                    response_used_messages[latest_long_input_index] = message_history[latest_long_input_index]  # If there is a user input that is longer than somewhat characters assume it as a code, put that into the response_used_messages assuming it is a code. If user submits an input that is longer than somewhat character one more time, replace it.
+
+                response_used_messages.update({i: message_history[i] for i in sorted(message_history.keys())[-3:]}) # Last 9 messages
+                response_used_messages = {key: response_used_messages[key] for key in sorted(response_used_messages.keys())}
 
                 user_id = message['author_id']
                 guild_id = message['guild_id']
 
                 await self._metrics_handler.record_message(
-                    guild_id, thread_id, user_id, message_history[-1]['role'], message_history[-1]['content'])
+                    guild_id, thread_id, user_id, message_index, message_history[message_index]['role'], message_history[message_index]['content'])
+
+                message_index += 1
 
                 message_history = self.reduce_history(message_history)
 
                 try:
-                    choices, usage = await self._get_completion(thread_id, engine, message_history)
+                    choices, usage = await self._get_completion(thread_id, engine, list(response_used_messages.values()))
                     response_message = choices[0]['message']
                     response = response_message['content'].strip()
 
@@ -135,15 +149,14 @@ class RubberDuck:
                                                              usage['completion_tokens'])
 
                     await self._metrics_handler.record_message(
-                        guild_id, thread_id, user_id, response_message['role'], response_message['content'])
+                        guild_id, thread_id, user_id, message_index, response_message['role'], response_message['content'])
 
-                    message_history.append(GPTMessage(role='assistant', content=response))
-  
-                    # After bot messages has added - check and message_history to have initial message (instruction) and 4 most recent messages
-                    if len(message_history) > 5:
-                        message_history = [message_history[0]] + message_history[-4:]
+                    message_history[message_index] = GPTMessage(role='assistant', content=response)
+                    message_index += 1
 
                     await self._send_message(thread_id, response)
+
+                    print(f"response used messages: {response_used_messages}")
 
                 except Exception as ex:
                     error_code = str(uuid.uuid4()).split('-')[0].upper()
@@ -182,3 +195,6 @@ class RubberDuck:
             choices = completion_dict['choices']
             usage = completion_dict['usage']
             return choices, usage
+
+# async def _summarize
+# make a recent_messages = [] and append that to message_history -> message_history.append(GPTMessage(role='system', content=summary))

--- a/rubber_duck.py
+++ b/rubber_duck.py
@@ -118,6 +118,8 @@ class RubberDuck:
                 await self._metrics_handler.record_message(
                     guild_id, thread_id, user_id, message_history[-1]['role'], message_history[-1]['content'])
 
+                message_history = self.reduce_history(message_history)
+
                 try:
                     choices, usage = await self._get_completion(thread_id, engine, message_history)
                     response_message = choices[0]['message']
@@ -152,7 +154,13 @@ class RubberDuck:
                                              f'\nPlease tell a TA or the instructor the error code.'
                                              '\n*This conversation is closed*')
                     return
-        
+    
+    # Keep message 0 for instruction and the last 20 messages
+    def reduce_history(self, message_history):
+        if len(message_history) > 20:
+            return [message_history[0]] + message_history[-20:]
+        return message_history
+
     @step
     async def _get_completion(self, thread_id, engine, message_history) -> tuple[list, dict]:
         # Replaces _get_response

--- a/rubber_duck.py
+++ b/rubber_duck.py
@@ -157,8 +157,8 @@ class RubberDuck:
     
     # Keep message 0 for instruction and the last 20 messages
     def reduce_history(self, message_history):
-        if len(message_history) > 4:
-            return [message_history[0]] + message_history[-4:]
+        if len(message_history) > 20:
+            return [message_history[0]] + message_history[-20:]
         return message_history
 
     @step

--- a/rubber_duck.py
+++ b/rubber_duck.py
@@ -112,6 +112,10 @@ class RubberDuck:
 
                 message_history.append(GPTMessage(role='user', content=message['content']))
 
+                # After user messages has added
+                # if len(message_history) > 5:
+                #     message_history = [message_history[0]] + message_history[-4:]
+
                 user_id = message['author_id']
                 guild_id = message['guild_id']
 
@@ -134,6 +138,10 @@ class RubberDuck:
                         guild_id, thread_id, user_id, response_message['role'], response_message['content'])
 
                     message_history.append(GPTMessage(role='assistant', content=response))
+  
+                    # After bot messages has added - check and message_history to have initial message (instruction) and 4 most recent messages
+                    if len(message_history) > 5:
+                        message_history = [message_history[0]] + message_history[-4:]
 
                     await self._send_message(thread_id, response)
 


### PR DESCRIPTION
1. Modified rubber_duck.py so that token could be limited - I modified message_history to have the initial message which is the instruction for the bot and then most recent 4 messages (for now). I think 4 is too small, so need to test some more using the long conversation.
2. I checked the usages.csv and checked prompt_token ,the token for input, to see if it is properly working.
3. I checked the bot by having conversation and seeing if the bot forgets after the most recent 4 messages.
I think this is the simplest way to limit the token and it is working great - just have to decide how many messages will be saved in the message_history. Could I get some feedback on this?