### PR TITLE
Group similar classes by channel

### DIFF
--- a/rubber_duck/discord_bot.py
+++ b/rubber_duck/discord_bot.py
@@ -138,7 +138,8 @@ class MyClient(discord.Client):
         wrap_steps(self.metrics_handler, ["record_message", "record_usage", "record_feedback"])
 
         config_adapter = ConfigAdapter(config)
-        reporter = Reporter(self.metrics_handler, config_adapter.adapt_metric_config(config['reporting']))
+        # reporting = config_adapter.adapt_metric_config()
+        reporter = Reporter(self.metrics_handler, config_adapter.adapt_metric_config())
 
         # Feedback
         get_ta_feedback = GetTAFeedback(
@@ -147,10 +148,8 @@ class MyClient(discord.Client):
             self.metrics_handler.record_feedback,
         )
 
-        feedback_configs = config['feedback']
-
         get_feedback = GetConvoFeedback(
-            feedback_configs,
+            config['course_channels'],
             get_ta_feedback
         )
 
@@ -362,10 +361,6 @@ def fetch_config_from_s3():
     
     # Get the S3 path from environment variables (CONFIG_FILE_S3_PATH should be set)
     s3_path = os.environ.get('CONFIG_FILE_S3_PATH')
-
-    environment = os.environ.get('ENVIRONMENT')
-    if environment == 'local':
-        return None
 
     if not s3_path:
         return None

--- a/rubber_duck/discord_bot.py
+++ b/rubber_duck/discord_bot.py
@@ -137,9 +137,14 @@ class MyClient(discord.Client):
         self.metrics_handler = SQLMetricsHandler(sql_session)
         wrap_steps(self.metrics_handler, ["record_message", "record_usage", "record_feedback"])
 
-        config_adapter = ConfigAdapter(config)
-        # reporting = config_adapter.adapt_metric_config()
-        reporter = Reporter(self.metrics_handler, config_adapter.adapt_metric_config())
+        if not config.get('reporting') and config.get('course_channels'):
+            config_adapter = ConfigAdapter(config)
+            reporter = Reporter(self.metrics_handler, config_adapter.adapt_metric_config())
+            feedback_configs = config['course_channels']
+        else:
+            # This makes the old config backwards compatible
+            reporter = Reporter(self.metrics_handler, config['reporting'])
+            feedback_configs = config['feedback']
 
         # Feedback
         get_ta_feedback = GetTAFeedback(
@@ -149,7 +154,7 @@ class MyClient(discord.Client):
         )
 
         get_feedback = GetConvoFeedback(
-            config['course_channels'],
+            feedback_configs,
             get_ta_feedback
         )
 

--- a/rubber_duck/discord_bot.py
+++ b/rubber_duck/discord_bot.py
@@ -140,11 +140,11 @@ class MyClient(discord.Client):
         if not config.get('reporting') and config.get('course_channels'):
             config_adapter = ConfigAdapter(config)
             reporter = Reporter(self.metrics_handler, config_adapter.adapt_metric_config())
-            feedback_configs = config['course_channels']
+            feedback_config = config_adapter.adapt_feedback_config()
         else:
             # This makes the old config backwards compatible
             reporter = Reporter(self.metrics_handler, config['reporting'])
-            feedback_configs = config['feedback']
+            feedback_config = config['feedback']
 
         # Feedback
         get_ta_feedback = GetTAFeedback(
@@ -154,7 +154,7 @@ class MyClient(discord.Client):
         )
 
         get_feedback = GetConvoFeedback(
-            feedback_configs,
+            feedback_config,
             get_ta_feedback
         )
 

--- a/rubber_duck/feedback.py
+++ b/rubber_duck/feedback.py
@@ -17,11 +17,9 @@ class RecordFeedback(Protocol):
     async def __call__(self, workflow_type: str, guild_id: int, thread_id: int, user_id: int, reviewer_id: int,
                        feedback_score: int): ...
 
-
 class GetFeedback(Protocol):
     async def __call__(self, workflow_type: str, guild_id: int, thread_id: int, user_id: int,
                        feedback_config: FeedbackConfig): ...
-
 
 class GetConvoFeedback:
     def __init__(self, feedback_configs: dict[str, FeedbackConfig], get_feedback: GetFeedback):
@@ -72,7 +70,7 @@ class GetTAFeedback:
                 await self._add_reaction(thread_id, feedback_message_id, reaction)
                 await asyncio.sleep(0.5)  # per discord policy, we wait
 
-            reviewer_channel_id = feedback_config['channel_id']
+            reviewer_channel_id = feedback_config['ta_review_channel_id']
             review_message_id = await self._send_message(reviewer_channel_id, review_message_content)
 
             try:


### PR DESCRIPTION
# Summary
We added an adapter class and simplified the config to put all of the settings together in a concise and easy to read way. This allows for servers to support multiple different subjects per server. (i.e. Phys 230 & 430) 

## Changes Needed By Dr Bean
Adjustments to the production config too include a newer simplified format. 

- [ ] I have attached a nearly complete production config set up for the physics classes. Download this and use it to get started. [v2-production-config.json](https://github.com/user-attachments/files/19859792/v2-production-config.json)
- [ ] You will need to include the feedback information for the other classes and their servers.

- [ ] You are going to need `"ta_review_channel_id": 1284224818698260490,` and the `"reviewer_role_id": 1011429191046144110` for each of the courses.


```json
{
  "rubber_duck": {
  "course_channels": {
    "1283486175675551786": {
      "channel_id": 1283486175675551786,
      "server_id": 1058490579799003187,
      "name": "BeanLab-Wiley-Channel",
      "feedback": {
        "ta_review_channel_id": 1284224818698260490,
        "reviewer_role_id": 1011429191046144110
      }
    },
    "1363949528201564170": {
      "channel_id": 1363949528201564170,
      "server_id": 1354902266246598928,
      "name": "Phys 230",
      "feedback": {
        "reviewer_role_id": 1011429191046144110,
        "ta_review_channel_id": 1363949553102880869
      }
    },
    "1359587525605458030": {
      "channel_id": 1359587525605458030,
      "server_id": 1354902266246598928,
      "name": "Phys 430",
      "feedback": {
        "reviewer_role_id": 1011429191046144110,
        "ta_review_channel_id": 1359587713749094700
      }
    }
  },
}
```