### PR TITLE
144-production-config-ci-cd

### DIFF
--- a/.github/scripts/upload-config.sh
+++ b/.github/scripts/upload-config.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Usage: ./upload-config.sh <local_file_path> <s3_bucket_name> <s3_key>
+
+# Exit if any command fails
+set -e
+
+# Input arguments
+LOCAL_FILE=$1
+BUCKET_NAME=$2
+S3_KEY=$3
+
+# Check if all arguments are provided
+if [[ -z "$LOCAL_FILE" || -z "$BUCKET_NAME" || -z "$S3_KEY" ]]; then
+  echo "Usage: $0 <local_file_path> <s3_bucket_name> <s3_key>"
+  echo "Example: $0 config/production-config.json my-config-bucket path/to/config/production-config.json"
+  exit 1
+fi
+
+# Validate that the file exists
+if [ ! -f "$LOCAL_FILE" ]; then
+  echo "Error: Local file '$LOCAL_FILE' does not exist."
+  exit 1
+fi
+
+echo "Uploading $LOCAL_FILE to s3://$BUCKET_NAME/$S3_KEY ..."
+
+# Upload to S3
+aws s3 cp "$LOCAL_FILE" "s3://$BUCKET_NAME/$S3_KEY"
+
+if [ $? -eq 0 ]; then
+  echo "✅ Upload successful!"
+else
+  echo "❌ Upload failed!"
+  exit 1
+fi

--- a/.github/workflows/update-production-config.yml
+++ b/.github/workflows/update-production-config.yml
@@ -1,6 +1,9 @@
 name: Update Production Config
 
 on:
+  push:
+    branches:
+      - 144-production-config-ci-cd
   workflow_run:
     workflows: ["CI/CD Workflow Name"]
     types:

--- a/.github/workflows/update-production-config.yml
+++ b/.github/workflows/update-production-config.yml
@@ -1,12 +1,9 @@
 name: Update Production Config
 
 on:
-  workflow_run:
-    workflows: ["CI/CD Workflow Name"]
-    types:
-      - completed
-  workflow_dispatch:
-
+  push:
+    branches:
+      - master
 jobs:
   update_the_production_config:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-production-config.yml
+++ b/.github/workflows/update-production-config.yml
@@ -1,9 +1,6 @@
 name: Update Production Config
 
 on:
-  push:
-    branches:
-      - 144-production-config-ci-cd
   workflow_run:
     workflows: ["CI/CD Workflow Name"]
     types:

--- a/.github/workflows/update-production-config.yml
+++ b/.github/workflows/update-production-config.yml
@@ -1,0 +1,25 @@
+name: Update Production Config
+
+on:
+  workflow_run:
+    workflows: ["CI/CD Workflow Name"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  update_the_production_config:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Upload Production Config
+        run: bash .github/scripts/upload-config.sh ${{secrets.S3_LOCAL_PRODUCTION_CONFIG_PATH}} ${{secrets.S3_BUCKET_NAME}} ${{secrets.S3_KEY}}

--- a/.github/workflows/update-production-config.yml
+++ b/.github/workflows/update-production-config.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+  
 jobs:
   update_the_production_config:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- After the main CI-CD pipeline completes another workflow will begin uploading the config.
- The workflow can also be manually triggered if the user just needs the config uploaded. All the user needs to do is go to GitHub to and manually trigger it.

## Changes
- Added a script to separate the AWS logic from the GitHub logic.
- Added a new workflow to update the production config.