### PR TITLE
256 repair config loading logic

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -149,7 +149,7 @@ jobs:
           DB_USER=${{ secrets.DB_USER }}
           DB_PASSWORD=${{ secrets.DB_PASSWORD }}
           ENVIRONMENT=pre-production
-          CONFIG_FILE_S3_PATH=s3://${{ secrets.S3_BUCKET_PRODUCTION_CONFIG_DIRECTORY }}/production-configs/${{ needs.Extract_SHA.outputs.short_sha }}.yaml
+          CONFIG_FILE_S3_PATH=${{ secrets.S3_BUCKET_PRODUCTION_CONFIG_DIRECTORY }}/production-configs${{ needs.Extract_SHA.outputs.short_sha }}.yaml
           EOL
 
       - name: Upload secrets to S3

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - 256-repair-config-loading-logic
   workflow_dispatch:
     inputs:
       local_config:
@@ -151,7 +150,7 @@ jobs:
           ENVIRONMENT=pre-production
           CONFIG_FILE_S3_PATH=${{ secrets.S3_BUCKET_PRODUCTION_CONFIG_DIRECTORY }}production-config-${{ needs.Extract_SHA.outputs.short_sha }}.yaml
           EOL
-#
+
       - name: Upload secrets to S3
         run: |
           SHORT_SHA="${{ needs.Extract_SHA.outputs.short_sha }}"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - 256-repair-config-loading-logic
   workflow_dispatch:
     inputs:
       local_config:
@@ -148,6 +149,7 @@ jobs:
           DB_USER=${{ secrets.DB_USER }}
           DB_PASSWORD=${{ secrets.DB_PASSWORD }}
           ENVIRONMENT=pre-production
+          CONFIG_FILE_S3_PATH=s3://${{ secrets.S3_BUCKET_PRODUCTION_CONFIG_DIRECTORY }}/production-configs/${{ needs.Extract_SHA.outputs.short_sha }}.yaml
           EOL
 
       - name: Upload secrets to S3

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -151,7 +151,7 @@ jobs:
           ENVIRONMENT=pre-production
           CONFIG_FILE_S3_PATH=${{ secrets.S3_BUCKET_PRODUCTION_CONFIG_DIRECTORY }}production-config-${{ needs.Extract_SHA.outputs.short_sha }}.yaml
           EOL
-
+#
       - name: Upload secrets to S3
         run: |
           SHORT_SHA="${{ needs.Extract_SHA.outputs.short_sha }}"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -149,7 +149,7 @@ jobs:
           DB_USER=${{ secrets.DB_USER }}
           DB_PASSWORD=${{ secrets.DB_PASSWORD }}
           ENVIRONMENT=pre-production
-          CONFIG_FILE_S3_PATH=${{ secrets.S3_BUCKET_PRODUCTION_CONFIG_DIRECTORY }}/production-configs${{ needs.Extract_SHA.outputs.short_sha }}.yaml
+          CONFIG_FILE_S3_PATH=${{ secrets.S3_BUCKET_PRODUCTION_CONFIG_DIRECTORY }}production-configs-${{ needs.Extract_SHA.outputs.short_sha }}.yaml
           EOL
 
       - name: Upload secrets to S3

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -149,7 +149,7 @@ jobs:
           DB_USER=${{ secrets.DB_USER }}
           DB_PASSWORD=${{ secrets.DB_PASSWORD }}
           ENVIRONMENT=pre-production
-          CONFIG_FILE_S3_PATH=${{ secrets.S3_BUCKET_PRODUCTION_CONFIG_DIRECTORY }}production-configs-${{ needs.Extract_SHA.outputs.short_sha }}.yaml
+          CONFIG_FILE_S3_PATH=${{ secrets.S3_BUCKET_PRODUCTION_CONFIG_DIRECTORY }}production-config-${{ needs.Extract_SHA.outputs.short_sha }}.yaml
           EOL
 
       - name: Upload secrets to S3

--- a/src/utils/config_loader.py
+++ b/src/utils/config_loader.py
@@ -66,7 +66,9 @@ def load_configuration(config_arg: str | None) -> Config:
     3. Handle S3 and local file loading with proper error handling
     """
     
-    config_path = os.environ.get('CONFIG_FILE_S3_PATH', config_arg) or 'config.json'
+    config_path = config_arg or os.environ.get('CONFIG_FILE_S3_PATH') or 'config.json'
+
+    duck_logger.info(f"Loading config from: {config_path}")
 
     if config_path.startswith('s3://'):
         return fetch_config_from_s3(config_path)


### PR DESCRIPTION
# Summary
When we load a config to production the env CONFIG_FILE_S3_PATH var will overwrite the command line argument. We need that logic swapped. So that we will first look first if we have a cmdline argument. If we do then we will load that config.
```python
if cmdline:
   load_config(cmdline)
elif CONFIG_FILE_S3_PATH in env:
   load_config(env)
else:
   load_default()
```
We also need to updated the ci-cd pipeline to add CONFIG_FILE_S3_PATH= as a preset variable.