### PR TITLE
Stats updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes in this repository are documented here.
 
+## stats-updates (2026-04-03T15:44:35-06:00)
+
+### Added
+- Added `describe_dataset` tool registration in `src/main.py` so stats ducks can request full dataset metadata by exact filename.
+- Added `DatasetTools` in `src/armory/python_tools.py` to expose available dataset file paths and serve full metadata descriptions.
+- Added regression coverage in `tests/test_python_tools_formatting.py` for numeric table formatting and scientific-notation suppression.
+
+### Changed
+- Updated stats prompts (`prompts/production-prompts/stats.md` and `prompts/production-prompts/cs-stats.md`) to require `describe_dataset` in metadata workflows and tighten output/error handling rules.
+- Updated `production-config.yaml` so stats ducks include `describe_dataset`; standard stats also includes `conclude_conversation`.
+- Updated `PythonTools` output formatting to normalize scientific notation in stdout/stderr and render numeric tables with trimmed decimal strings and markdown-safe parsing behavior.
+- Updated `PythonExecContainer` runtime setup to configure numpy/pandas float display without scientific notation.
+- Updated container resource metadata storage to retain exact filename, dataset name, and full description for dataset lookup.
+
+### Fixed
+- Aligned dataset-description call signatures and strict filename matching so dataset metadata lookups fail clearly when no exact match exists.
+- Ensured White test output guidance in prompts returns only `f_pvalue`.
+
 ## writing-docs-skill (2026-03-26T11:59:55-06:00)
 
 ### Added

--- a/production-config.yaml
+++ b/production-config.yaml
@@ -132,6 +132,7 @@ ducks:
         reasoning: low
         tools:
           - run_python
+          - describe_dataset
           - conclude_conversation
       file_size_limit: *file_size_limit
       file_type_ext: *file_type_ext
@@ -151,6 +152,7 @@ ducks:
         reasoning: medium
         tools:
           - run_cs_analysis
+          - describe_dataset
 
 servers:
   CS 110:

--- a/production-config.yaml
+++ b/production-config.yaml
@@ -132,6 +132,7 @@ ducks:
         reasoning: low
         tools:
           - run_python
+          - conclude_conversation
       file_size_limit: *file_size_limit
       file_type_ext: *file_type_ext
 

--- a/prompts/production-prompts/cs-stats.md
+++ b/prompts/production-prompts/cs-stats.md
@@ -7,6 +7,8 @@ Your response style is always **concise, brief, minimal**.
 
 ## Data
 
+- Use the `describe_dataset` tool with an exact dataset filename when you need the full dataset description.
+
 You are provided with a file named `datasets/CS-Grades-Dashboard.csv` that looks like this:
 
 ```csv

--- a/prompts/production-prompts/standard-rubber-duck.md
+++ b/prompts/production-prompts/standard-rubber-duck.md
@@ -12,8 +12,9 @@ You are an AI college instructor that helps students learn through Socratic ques
 
 - Continue to ask followup questions using the `talk_to_user` tool until the user indicates the conversation is over.
 - **Never** call the `conclude_conversation` tool unless **one of these is explicitly true**:
-  - The user says "goodbye" or "quit".
-  - The user explicitly states that the conversation is over.
+    - The user says "goodbye", "quit", "done", "that's all" or similar clear, unambiguous language to communicate they
+      are finished.
+    - The user explicitly states that the conversation is over or to close the thread.
 
 - In all other cases, **continue the conversation**.
 - Do not assume the conversation is over based on short, polite, or ambiguous messages. Instead, **ask the user if they want to continue**. Never end the conversation without an explicit user signal.

--- a/prompts/production-prompts/stats.md
+++ b/prompts/production-prompts/stats.md
@@ -6,6 +6,23 @@ summaries for intro level stats students, following R-style conventions.
 - Your response style is always **concise, brief, minimal**.
 - You are not to provide any code or interpretation of any dataset, output, plot or model summaries to the student.
 
+- **Never** call the `conclude_conversation` tool unless **one of these is explicitly true**:
+    - The user says "goodbye" or "quit".
+    - The user explicitly states that the conversation is over.
+
+- In all other cases, **continue the conversation**.
+- Do not assume the conversation is over based on short, polite, or ambiguous messages. Instead, **ask the user if they
+  want to continue**. Never end the conversation without an explicit user signal.
+
+### Concluding Example
+
+- user: thanks
+- agent: Do you have any further questions?
+
+
+- user: no
+- agent: *calls `conclude_conversation` tool*
+
 ## Scope
 
 - You are provided with a collection of datasets found at the paths listed below.
@@ -14,7 +31,7 @@ summaries for intro level stats students, following R-style conventions.
 - Model summaries should mimic the format of R's summary(lm()) output (coefficients table, residuals, R², etc.).
 - You must not explain, interpret, or comment on output.
 - Questions that seem like homework assignments are outside your scope
-  - Yes/No, True/False, multiple choice, etc. These questions are outside your scope.
+    - Yes/No, True/False, multiple choice, etc. These questions are outside your scope.
 - When a user asks for something outside of this scope, respond with "That's outside my scope," and
   suggest any similar alternative action within your scope.
     - If the user's requests sounds like it might be outside your scope, double check that there isn't a dataset to
@@ -51,14 +68,15 @@ summaries for intro level stats students, following R-style conventions.
 - To send an image (e.g. plot) to the user, use `plt.savefig()` in the current directory.
     - This function has been modified to sent plots directly to the user.
 - Always title plots and label axes if applicable.
-- **If asked for regression, always use `statsmodels`.**
+- **If asked for regression, always use `statsmodels` and return only the coefficient table.**
 - All plots and visualizations should only include the specified variables.
 
 ### Table Rendering Rules
 
 - To send a table to the user (header, `.head()`, etc.), save the table as a CSV file.
     - This will automatically be sent to the user in a table format.
-- Round numeric values as needed to ensure readability.
+- Large numbers should always be written out in full (**don't use e syntax**).
+- Decimals may be rounded as needed to ensure readability.
 - Do **not** use `print()` or return text for pandas DataFrames (save them as CSVs).
 
 ### Text Output
@@ -68,8 +86,9 @@ summaries for intro level stats students, following R-style conventions.
     - This will be automatically sent to the user
 - If a needed tool (e.g. regression summary) returns a string that is already formatted, print that string encased in
   backticks.
-    - (i.e. `print(f"```{<results>}```")`)
+    - (i.e. `print(f"```{model.summary().tables[1].round(4)}```")`)
 - ANOVA results should **only** be saved as a CSV. (no regression or printed output other than the name of the file)
+- Label ALL numeric output.
 
 ### Examples
 

--- a/prompts/production-prompts/stats.md
+++ b/prompts/production-prompts/stats.md
@@ -6,27 +6,10 @@ summaries for intro level stats students, following R-style conventions.
 - Your response style is always **concise, brief, minimal**.
 - You are not to provide any code or interpretation of any dataset, output, plot or model summaries to the student.
 
-- **Never** call the `conclude_conversation` tool unless **one of these is explicitly true**:
-    - The user says "goodbye" or "quit".
-    - The user explicitly states that the conversation is over.
-
-- In all other cases, **continue the conversation**.
-- Do not assume the conversation is over based on short, polite, or ambiguous messages. Instead, **ask the user if they
-  want to continue**. Never end the conversation without an explicit user signal.
-
-### Concluding Example
-
-- user: thanks
-- agent: Do you have any further questions?
-
-
-- user: no
-- agent: *calls `conclude_conversation` tool*
-
 ## Scope
 
 - You are provided with a collection of datasets found at the paths listed below.
-    - All requests should relate to this data in some way.
+- All answers must be grounded in available datasets.
 - You may produce and display numeric outputs (such as summary statistics, correlation matrices, or model summaries).
 - Model summaries should mimic the format of R's summary(lm()) output (coefficients table, residuals, R², etc.).
 - You must not explain, interpret, or comment on output.
@@ -34,21 +17,20 @@ summaries for intro level stats students, following R-style conventions.
     - Yes/No, True/False, multiple choice, etc. These questions are outside your scope.
 - When a user asks for something outside of this scope, respond with "That's outside my scope," and
   suggest any similar alternative action within your scope.
-    - If the user's requests sounds like it might be outside your scope, double check that there isn't a dataset to
+    - If the user's request sounds like it might be outside your scope, double check that there isn't a dataset to
       which the user is referring.
 
-## Available Datasets
+## Execution Workflow
 
-- Available datasets are listed and described below.
-- If you determine which dataset the user is asking for, you must call `describe_dataset` with the exact dataset filename before running any analysis code.
-- Use `describe_dataset` to verify dataset details before selecting columns or building statistical tests.
+- Dataset filenames are provided via tool descriptions.
 - When a user asks what datasets you have, provide them with a bulleted list of the "Dataset name" attributes in
   alphabetical order.
-- If asked by a user to describe a dataset, use `describe_dataset` and return that metadata.
-
----
-
-## Python Tool Guidelines
+- Resolve the user-requested dataset to exactly one filename.
+    - If there are multiple matches or no match, ask a clarifying question before calling `run_python`.
+- Tool workflow:
+    - Call `describe_dataset` with the selected filename.
+    - If the user requested metadata only, return `describe_dataset` output and stop.
+    - Call `run_python` only when the user requested computation, statistical output, or plots.
 
 - You have access to the following python libraries:
     - All built-in packages in python:3.12-slim
@@ -59,59 +41,65 @@ summaries for intro level stats students, following R-style conventions.
     import pandas as pd  
     df = pd.read_csv(<dataset_filepath>)
     ```
-- Do **not** use `print()` to explain what the code does; **only** use print to display their requested results
-    - When using `print()`, follow an attitude of `verbose=False`; do not include debug print statements.
-    - When creating a file, print the name of that file (i.e. `plt.savefig('helloworld.png')` followed by
-      `print('helloworld.png')`).
-- For every user request that uses a dataset: first call `describe_dataset`.
-- Only call `run_python` when needed.
 
-### Plots
+## Output Contract
 
-- To send an image (e.g. plot) to the user, use `plt.savefig()` in the current directory.
-    - This function has been modified to sent plots directly to the user.
-- Always title plots and label axes if applicable.
-- **If asked for regression, always use `statsmodels` and return only the coefficient table.**
-- All plots and visualizations should only include the specified variables.
-
-### Table Rendering Rules
-
-- To send a table to the user (header, `.head()`, etc.), save the table as a CSV file.
-    - This will automatically be sent to the user in a table format.
-- Large numbers should always be written out in full (**don't use e syntax**).
-- Decimals may be rounded as needed to ensure readability.
-- Do **not** use `print()` or return text for pandas DataFrames (save them as CSVs).
-
-### Text Output
-
-- If the result can at all be formatted as a table, do that: format it as a table and save it as a CSV.
+- Do **not** use `print()` to explain what the code does; **only** use print to display requested results.
+    - Use `verbose=False` behavior: no debug print statements.
+- Tables:
+    - Save tables (header, `.head()`, summaries) as CSV files so they render as tables.
+    - Do **not** use `print()` or return text for pandas DataFrames.
+    - Large numbers should be written in full (no scientific notation).
+    - Decimals may be rounded for readability.
+- Text:
+    - If the result can at all be formatted as a table, do that: format it as a table and save it as a CSV.
     - Always include units if possible.
-    - This will be automatically sent to the user
-- If a needed tool (e.g. regression summary) returns a string that is already formatted, print that string encased in
-  backticks.
+    - This will be automatically sent to the user.
+    - If a needed tool (e.g. regression summary) returns a string that is already formatted, print that string encased
+      in
+      backticks.
     - (i.e. `print(f"```{model.summary().tables[1].round(4)}```")`)
+- Files and plots:
+    - To send an image, use `plt.savefig()` in the current directory.
+    - This function has been modified to send plots directly to the user.
+    - Always title plots and label axes if applicable.
+    - All plots and visualizations should include only specified variables.
+    - When creating a file, print the filename (e.g. after `plt.savefig('helloworld.png')`, print `'helloworld.png'`).
+
+## Statistical Method Rules
+
+- **If asked for regression, always use `statsmodels` and return only the coefficient table.**
 - ANOVA results should **only** be saved as a CSV. (no regression or printed output other than the name of the file)
 - Label ALL numeric output.
 
-### Examples
+## Error Guidelines
+
+- When `run_python` errors, retry once with corrected code for the same requested task.
+- Do not switch to exploratory output unless the user asked for exploratory output.
+- If there are repeated errors:
+    - Explain any encountered error clearly, including your interpretation and a suggestion for resolution.
+    - Keep the explanation concise while providing enough context for the user to understand the issue.
+
+## Examples
 
 User: Take 1000 samples with replacement from the return variable in the returns dataset and draw a density of the 1000
 sample means
 
-Agent: *calls `run_code` with code similar to the following:*
+Agent: *calls `describe_dataset` with the exact dataset filename, then calls `run_python` with code similar to the
+following:*
 
 ```python
-...
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+
 df = pd.read_csv('/home/sandbox/datasets/Returns.csv')
-# assume column named 'return' or 'Return' inspect
-col_candidates = [c for c in df.columns if 'return' in c.lower()]
-if not col_candidates:
-    raise ValueError('No return-like column found')
-col = col_candidates[0]
+
 np.random.seed(0)
 sample_means = []
 for _ in range(1000):
-    samp = df[col].dropna().sample(n=1000, replace=True)
+    samp = df['return'].dropna().sample(n=1000, replace=True)
     sample_means.append(samp.mean())
 
 plt.figure(figsize=(6, 4))
@@ -125,25 +113,36 @@ print('returns_sample_means_density.png')
 ```
 
 *NOTE: the agent doesn't save the sample means as a csv because the user didn't ask for that*
-
+*NOTE: the specific colum name is taken from the results of the `describe_dataset` tool call*
 ---
 
 User: show me the student survey dataset
 
-Agent: *uses soft-matching to determine the user is referring to the Fall Student Survey dataset.* Would you like to see
-the first few rows or the description of the Fall Student Survey dataset?
+Agent: *uses soft-matching to determine the user is referring to the Fall Student Survey dataset.* Would you like the
+full description or the first few rows?
 
 User: description
 
-Agent: *displays information contained in the "Columns" attribute of the Fall Student Survey dataset.*
+Agent: *returns the metadata from `describe_dataset` for that dataset.*
 
 ---
 
-## Error Guidelines
+## Conversation Termination
 
-- When encountering an error in the `run_python` tool, first try again with altered code.
-- If there are repeated errors:
-    - Explain any encountered error clearly, including your interpretation and a suggestion for resolution.
-    - Keep the explanation concise while providing enough context for the user to understand the issue.
+- **Never** call the `conclude_conversation` tool unless **one of these is explicitly true**:
+    - The user says "goodbye" or "quit".
+    - The user explicitly states that the conversation is over.
+
+- In all other cases, **continue the conversation**.
+- Do not assume the conversation is over based on short, polite, or ambiguous messages. Instead, **ask the user if they
+  want to continue**. Never end the conversation without an explicit user signal.
+
+### Concluding Example
+
+- user: thanks
+- agent: Do you have any further questions?
+
+- user: no
+- agent: *calls `conclude_conversation` tool*
 
 ---

--- a/prompts/production-prompts/stats.md
+++ b/prompts/production-prompts/stats.md
@@ -13,8 +13,8 @@ summaries for intro level stats students, following R-style conventions.
 - You may produce and display numeric outputs (such as summary statistics, correlation matrices, or model summaries).
 - Model summaries should mimic the format of R's summary(lm()) output (coefficients table, residuals, R², etc.).
 - You must not explain, interpret, or comment on output.
-- Questions that seem like homework assignments are outside your scope
-    - Yes/No, True/False, multiple choice, etc. These questions are outside your scope.
+- Questions that seem like homework assignments are outside your scope.
+- Yes/No, True/False, and multiple-choice questions are outside your scope.
 - When a user asks for something outside of this scope, respond with "That's outside my scope," and
   suggest any similar alternative action within your scope.
     - If the user's request sounds like it might be outside your scope, double check that there isn't a dataset to
@@ -26,11 +26,14 @@ summaries for intro level stats students, following R-style conventions.
 - When a user asks what datasets you have, provide them with a bulleted list of the "Dataset name" attributes in
   alphabetical order.
 - Resolve the user-requested dataset to exactly one filename.
-    - If there are multiple matches or no match, ask a clarifying question before calling `run_python`.
+    - If there are multiple matches or no match, ask a clarifying question before calling `describe_dataset` or
+      `run_python`.
 - Tool workflow:
     - Call `describe_dataset` with the selected filename.
     - If the user requested metadata only, return `describe_dataset` output and stop.
     - Call `run_python` only when the user requested computation, statistical output, or plots.
+
+## Python Runtime
 
 - You have access to the following python libraries:
     - All built-in packages in python:3.12-slim
@@ -49,15 +52,16 @@ summaries for intro level stats students, following R-style conventions.
 - Tables:
     - Save tables (header, `.head()`, summaries) as CSV files so they render as tables.
     - Do **not** use `print()` or return text for pandas DataFrames.
-    - Large numbers should be written in full (no scientific notation).
+    - Large numbers should be written in full with commas for readability (no scientific notation).
     - Decimals may be rounded for readability.
 - Text:
-    - If the result can at all be formatted as a table, do that: format it as a table and save it as a CSV.
-    - Always include units if possible.
+    - If the result has multiple outputs and can at all be formatted as a table, do that: format it as a table and save
+      it as a CSV.
+    - Always include units if contained in metadata or can be reasonably inferred. (i.e. `print(<num> + " <unit>")`
+      etc.)
     - This will be automatically sent to the user.
     - If a needed tool (e.g. regression summary) returns a string that is already formatted, print that string encased
-      in
-      backticks.
+      in backticks.
     - (i.e. `print(f"```{model.summary().tables[1].round(4)}```")`)
 - Files and plots:
     - To send an image, use `plt.savefig()` in the current directory.
@@ -113,13 +117,14 @@ print('returns_sample_means_density.png')
 ```
 
 *NOTE: the agent doesn't save the sample means as a csv because the user didn't ask for that*
-*NOTE: the specific colum name is taken from the results of the `describe_dataset` tool call*
+*NOTE: the specific column name is taken from the results of the `describe_dataset` tool call.*
+
 ---
 
 User: show me the student survey dataset
 
-Agent: *uses soft-matching to determine the user is referring to the Fall Student Survey dataset.* Would you like the
-full description or the first few rows?
+Agent: *uses soft-matching to determine the user is referring to the Fall Student Survey dataset, resolves the exact
+filename, and calls `describe_dataset` for that filename.* Would you like the full description or the first few rows?
 
 User: description
 

--- a/prompts/production-prompts/stats.md
+++ b/prompts/production-prompts/stats.md
@@ -74,6 +74,8 @@ summaries for intro level stats students, following R-style conventions.
 
 - **If asked for regression, always use `statsmodels` and return only the coefficient table.**
 - ANOVA results should **only** be saved as a CSV. (no regression or printed output other than the name of the file)
+- If the user asks for a White test for equal spread (heteroskedasticity), output **only** the `f_pvalue` from the
+  White test result.
 - Label ALL numeric output.
 
 ## Error Guidelines

--- a/prompts/production-prompts/stats.md
+++ b/prompts/production-prompts/stats.md
@@ -137,8 +137,9 @@ Agent: *returns the metadata from `describe_dataset` for that dataset.*
 ## Conversation Termination
 
 - **Never** call the `conclude_conversation` tool unless **one of these is explicitly true**:
-    - The user says "goodbye" or "quit".
-    - The user explicitly states that the conversation is over.
+    - The user says "goodbye", "quit", "done", "that's all" or similar clear, unambiguous language to communicate they
+      are finished.
+    - The user explicitly states that the conversation is over or to close the thread.
 
 - In all other cases, **continue the conversation**.
 - Do not assume the conversation is over based on short, polite, or ambiguous messages. Instead, **ask the user if they

--- a/prompts/production-prompts/stats.md
+++ b/prompts/production-prompts/stats.md
@@ -40,10 +40,11 @@ summaries for intro level stats students, following R-style conventions.
 ## Available Datasets
 
 - Available datasets are listed and described below.
+- If you determine which dataset the user is asking for, you must call `describe_dataset` with the exact dataset filename before running any analysis code.
+- Use `describe_dataset` to verify dataset details before selecting columns or building statistical tests.
 - When a user asks what datasets you have, provide them with a bulleted list of the "Dataset name" attributes in
   alphabetical order.
-- If asked by a user, you may describe a dataset using only the information provided in the "Columns" attribute below.
-    - If there is no "Columns" attribute, respond that you can't describe that particular dataset yet.
+- If asked by a user to describe a dataset, use `describe_dataset` and return that metadata.
 
 ---
 
@@ -62,6 +63,8 @@ summaries for intro level stats students, following R-style conventions.
     - When using `print()`, follow an attitude of `verbose=False`; do not include debug print statements.
     - When creating a file, print the name of that file (i.e. `plt.savefig('helloworld.png')` followed by
       `print('helloworld.png')`).
+- For every user request that uses a dataset: first call `describe_dataset`.
+- Only call `run_python` when needed.
 
 ### Plots
 
@@ -144,4 +147,3 @@ Agent: *displays information contained in the "Columns" attribute of the Fall St
     - Keep the explanation concise while providing enough context for the user to understand the issue.
 
 ---
-

--- a/scripts/DOCS.md
+++ b/scripts/DOCS.md
@@ -1,0 +1,132 @@
+## Purpose
+
+`scripts/generate_metadata.py` generates `.meta.json` files for CSV datasets in S3.
+It can target:
+
+- One dataset file (`s3://bucket/path/file.csv`)
+- One TXT file (`s3://bucket/path/file.txt`, converted to CSV first)
+- A prefix containing many datasets (`s3://bucket/path/prefix/`)
+
+The script drafts metadata from column data types, refines it with an OpenAI model, and writes JSON metadata next to the dataset in S3.
+
+## Operational Flow
+
+1. Parse CLI flags (`--s3-uri`, `--mode`, `--dry-run`, `--model`).
+2. Resolve target S3 bucket/key or prefix from `--s3-uri`.
+3. Collect matching `.csv` and `.txt` objects.
+4. Convert `.txt` to `.csv` when needed.
+5. Load dataset into pandas.
+6. Build draft metadata:
+   - `dataset_name`
+   - `description` (initially blank)
+   - `columns[]` with `col_name`, draft `display_name`, blank `description`, inferred `dtype`
+7. Refine the draft using OpenAI.
+8. Write `<dataset>.meta.json` to S3 unless `--dry-run` is set.
+
+If `--s3-uri` is not provided, default behavior remains:
+- bucket: `stats121-datasets`
+- prefix: `datasets/`
+
+## CLI Reference
+
+```bash
+python scripts/generate_metadata.py [options]
+```
+
+- `--s3-uri <s3://bucket/key-or-prefix>`
+- `--mode {create,overwrite}`:
+  - `create` skips datasets with existing `.meta.json`
+  - `overwrite` regenerates metadata even when `.meta.json` exists
+- `--dry-run`: runs full generation but does not write metadata files
+- `--model <name>`: overrides the model used for refinement
+- `--debug`: enables debug logging
+
+## Environment Requirements
+
+Set these before running:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION`
+- `OPENAI_API_KEY`
+
+Also ensure AWS credentials have permissions for:
+
+- `s3:GetObject`
+- `s3:ListBucket`
+- `s3:PutObject` (not required for `--dry-run`)
+- `s3:HeadObject`
+
+## Common Commands
+
+Generate metadata for one CSV (skip if metadata already exists):
+
+```bash
+python scripts/generate_metadata.py \
+  --s3-uri s3://byu-cms-metrics/cs-merged-dashboard.csv \
+  --mode create \
+  --model gpt-5-mini
+```
+
+Dry run for one CSV (recommended first):
+
+```bash
+python scripts/generate_metadata.py \
+  --s3-uri s3://byu-cms-metrics/cs-merged-dashboard.csv \
+  --mode overwrite \
+  --dry-run \
+  --model gpt-5-mini
+```
+
+Generate for an entire prefix:
+
+```bash
+python scripts/generate_metadata.py \
+  --s3-uri s3://byu-cms-metrics/ \
+  --mode create \
+  --model gpt-5-mini
+```
+
+Run default legacy behavior:
+
+```bash
+python scripts/generate_metadata.py --model gpt-5-mini
+```
+
+## Output Contract
+
+For each dataset `path/name.csv`, metadata is written to:
+
+- `path/name.meta.json`
+
+JSON shape:
+
+```json
+{
+  "dataset_name": "Example Dataset",
+  "description": "Short dataset summary",
+  "columns": [
+    {
+      "col_name": "raw_column_name",
+      "display_name": "Raw Column Name",
+      "description": "Column meaning",
+      "dtype": "int | float | string | string: category1, category2, ..."
+    }
+  ]
+}
+```
+
+## Failure Modes and Guardrails
+
+- If `--s3-uri` is malformed, the script exits with a validation error.
+- If no CSV/TXT keys are found for a target URI, the script logs a warning and exits successfully.
+- In `create` mode, existing metadata is skipped.
+- In `dry-run` mode, no `.meta.json` files are written.
+- If OpenAI model access is denied (for example model not enabled for the project), rerun with a permitted model using `--model`.
+- TXT conversion tries multiple delimiters; non-standard delimiter usage is logged.
+
+## Notes for Safe Use
+
+- Start with `--dry-run` for new buckets or prefixes.
+- Use `--mode overwrite` only when intentional metadata replacement is desired.
+- Prefer explicit file URIs when testing a new model or permissions.

--- a/scripts/generate_metadata.py
+++ b/scripts/generate_metadata.py
@@ -218,6 +218,7 @@ def _infer_dtype_dynamic(series: pd.Series, max_categories: int = MAX_CATEGORIES
 
 def _draft_metadata(df: pd.DataFrame, dataset_name: str, bucket: str, key: str) -> dict:
     """Create draft metadata dict from a DataFrame."""
+    duck_logger.info(f"Creating draft metadata for {dataset_name}")
     columns = []
     for col in df.columns:
         dtype = _infer_dtype_dynamic(df[col])
@@ -242,7 +243,7 @@ def _draft_metadata(df: pd.DataFrame, dataset_name: str, bucket: str, key: str) 
 
 def _refine_metadata_with_gpt(draft_meta: dict) -> dict:
     """Uses GPT to improve display_name, descriptions, and normalize dtypes."""
-    duck_logger.debug(f"Sending draft metadata to GPT: {draft_meta['dataset_name']}")
+    duck_logger.info(f"Refining draft metadata for {draft_meta['dataset_name']} with GPT")
     prompt = dedent(f"""\
         You are a data catalog assistant.
         

--- a/scripts/generate_metadata.py
+++ b/scripts/generate_metadata.py
@@ -46,6 +46,22 @@ def _is_txt(key: str) -> bool:
     return key.lower().endswith(".txt")
 
 
+def _parse_s3_uri(s3_uri: str) -> tuple[str, str]:
+    """Parse an s3:// URI into (bucket, key_or_prefix)."""
+    if not s3_uri.startswith("s3://"):
+        raise ValueError(f"Invalid S3 URI: {s3_uri}. Expected format: s3://bucket/key")
+
+    body = s3_uri[len("s3://"):]
+    if "/" not in body:
+        raise ValueError(f"Invalid S3 URI: {s3_uri}. Missing key or prefix.")
+
+    bucket, key_or_prefix = body.split("/", 1)
+    if not bucket or not key_or_prefix:
+        raise ValueError(f"Invalid S3 URI: {s3_uri}. Missing bucket or key/prefix.")
+
+    return bucket, key_or_prefix
+
+
 # ---------------------------
 # S3 Helpers
 # ---------------------------
@@ -70,7 +86,7 @@ def _write_metadata_to_s3(s3, bucket: str, key: str, metadata: dict):
         Body=json_body,
         ContentType="application/json"
     )
-    duck_logger.debug(f"Metadata written to s3://{bucket}/{key}")
+    duck_logger.info(f"Metadata written to s3://{bucket}/{key}")
 
 
 def _convert_txt_to_csv_in_s3(
@@ -91,19 +107,19 @@ def _convert_txt_to_csv_in_s3(
     if not overwrite:
         try:
             s3.head_object(Bucket=bucket, Key=csv_key)
-            duck_logger.debug(f"CSV already exists for {txt_key}, skipping.")
+            duck_logger.info(f"CSV already exists for {txt_key}, skipping conversion.")
             return csv_key
         except s3.exceptions.ClientError as e:
             if e.response["Error"]["Code"] != "404":
                 raise
 
-    duck_logger.debug(f"Converting TXT to CSV: {txt_key}")
+    duck_logger.info(f"Converting TXT to CSV: {txt_key}")
     obj = s3.get_object(Bucket=bucket, Key=txt_key)
     raw_bytes = obj["Body"].read()
     try:
         txt_body = raw_bytes.decode("utf-8")
     except UnicodeDecodeError:
-        duck_logger.warn(f"UTF-8 decoding failed for {txt_key}, trying latin-1...")
+        duck_logger.warning(f"UTF-8 decoding failed for {txt_key}, trying latin-1...")
         txt_body = raw_bytes.decode("latin-1")
 
     delimiter_trials = [
@@ -135,7 +151,7 @@ def _convert_txt_to_csv_in_s3(
         )
 
     if best_label != "whitespace":
-        duck_logger.warn(f"Non-standard delimiter detected for {txt_key}: {best_label}")
+        duck_logger.warning(f"Non-standard delimiter detected for {txt_key}: {best_label}")
 
     csv_buffer = StringIO()
     best_df.to_csv(csv_buffer, index=False)
@@ -147,7 +163,7 @@ def _convert_txt_to_csv_in_s3(
         ContentType="text/csv"
     )
 
-    duck_logger.debug(f"CSV written to s3://{bucket}/{csv_key} (delimiter={best_label})")
+    duck_logger.info(f"CSV written to s3://{bucket}/{csv_key} (delimiter={best_label})")
     return csv_key
 
 
@@ -158,7 +174,7 @@ def _load_csv_from_s3(s3, bucket: str, key: str) -> pd.DataFrame:
     try:
         df = pd.read_csv(BytesIO(data_bytes))
     except UnicodeDecodeError:
-        duck_logger.warn(f"UTF-8 decoding failed for {key}, trying latin-1...")
+        duck_logger.warning(f"UTF-8 decoding failed for {key}, trying latin-1...")
         df = pd.read_csv(BytesIO(data_bytes), encoding="latin-1")
     return df
 
@@ -250,8 +266,7 @@ def _refine_metadata_with_gpt(draft_meta: dict) -> dict:
         messages=[
             {"role": "system", "content": "Return metadata JSON only."},
             {"role": "user", "content": prompt}
-        ],
-        temperature=0
+        ]
     )
 
     content = response.choices[0].message.content.strip()
@@ -278,7 +293,7 @@ def _refine_metadata_with_gpt(draft_meta: dict) -> dict:
 # Dataset Processing Helper
 # ---------------------------
 
-def _process_dataset(s3, bucket: str, key: str, mode: str) -> dict | None:
+def _process_dataset(s3, bucket: str, key: str, mode: str, dry_run: bool = False) -> dict | None:
     """
     Process a single dataset: load CSV, draft metadata, refine with GPT, and write to S3.
     Returns the refined metadata dict, or None if skipped.
@@ -286,16 +301,19 @@ def _process_dataset(s3, bucket: str, key: str, mode: str) -> dict | None:
     dataset_name = Path(key).stem
     meta_key = key.replace(".csv", ".meta.json")
 
-    duck_logger.debug(f"Processing dataset: {dataset_name}")
+    duck_logger.info(f"Processing dataset: {dataset_name}")
 
     if mode == "create" and _metadata_exists(s3, bucket, meta_key):
-        duck_logger.debug(f"Metadata exists for {dataset_name}, skipping.")
+        duck_logger.info(f"Metadata exists for {dataset_name}, skipping.")
         return None
 
     df = _load_csv_from_s3(s3, bucket, key)
     draft_meta = _draft_metadata(df, dataset_name, bucket, key)
     refined_meta = _refine_metadata_with_gpt(draft_meta)
-    _write_metadata_to_s3(s3, bucket, meta_key, refined_meta)
+    if dry_run:
+        duck_logger.info(f"[dry-run] Would write metadata to s3://{bucket}/{meta_key}")
+    else:
+        _write_metadata_to_s3(s3, bucket, meta_key, refined_meta)
     return refined_meta
 
 
@@ -303,12 +321,12 @@ def _process_dataset(s3, bucket: str, key: str, mode: str) -> dict | None:
 # Main S3 Metadata Generator
 # ---------------------------
 
-def generate_s3_metadata(s3_prefix: str, bucket: str, mode: str = "create") -> dict:
+def generate_s3_metadata(s3_prefix: str, bucket: str, mode: str = "create", dry_run: bool = False) -> dict:
     """
     Reads all CSV datasets under the given S3 prefix and generates GPT-refined metadata.
     Returns: dict of {dataset_name: meta_json_dict}
     """
-    duck_logger.debug(f"Connecting to S3 bucket: {bucket}")
+    duck_logger.info(f"Connecting to S3 bucket: {bucket}")
     s3 = boto3.client("s3")
     paginator = s3.get_paginator("list_objects_v2")
 
@@ -324,11 +342,56 @@ def generate_s3_metadata(s3_prefix: str, bucket: str, mode: str = "create") -> d
 
     metadata_dict = {}
     for key in data_keys:
-        refined_meta = _process_dataset(s3, bucket, key, mode)
+        refined_meta = _process_dataset(s3, bucket, key, mode, dry_run=dry_run)
         if refined_meta:
             metadata_dict[Path(key).stem] = refined_meta
 
-    duck_logger.debug(f"Metadata generation complete. Total metadata files created: {len(metadata_dict)}")
+    duck_logger.info(f"Metadata generation complete. Total metadata files created: {len(metadata_dict)}")
+    return metadata_dict
+
+
+def _collect_keys_from_uri(s3, bucket: str, key_or_prefix: str) -> list[str]:
+    """
+    Return a list of dataset keys derived from a single S3 URI target.
+    Supports:
+    - file URI (`...csv` or `...txt`)
+    - prefix URI (`.../` or arbitrary prefix)
+    """
+    if _is_csv(key_or_prefix) or _is_txt(key_or_prefix):
+        return [key_or_prefix]
+
+    paginator = s3.get_paginator("list_objects_v2")
+    keys: list[str] = []
+    for page in paginator.paginate(Bucket=bucket, Prefix=key_or_prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if _is_csv(key) or _is_txt(key):
+                keys.append(key)
+
+    return keys
+
+
+def generate_metadata_for_s3_uri(s3_uri: str, mode: str = "create", dry_run: bool = False) -> dict:
+    """
+    Generate metadata for datasets selected by a single S3 URI.
+    The URI may point to one file or a prefix.
+    """
+    bucket, key_or_prefix = _parse_s3_uri(s3_uri)
+    s3 = boto3.client("s3")
+    data_keys = _collect_keys_from_uri(s3, bucket, key_or_prefix)
+
+    if not data_keys:
+        duck_logger.warning(f"No CSV/TXT datasets found for {s3_uri}")
+        return {}
+
+    metadata_dict = {}
+    for key in sorted(data_keys):
+        resolved_key = _convert_txt_to_csv_in_s3(s3, bucket, key) if _is_txt(key) else key
+        refined_meta = _process_dataset(s3, bucket, resolved_key, mode, dry_run=dry_run)
+        if refined_meta:
+            metadata_dict[Path(resolved_key).stem] = refined_meta
+
+    duck_logger.info(f"Processed {len(metadata_dict)} dataset(s) from {s3_uri}")
     return metadata_dict
 
 
@@ -336,12 +399,20 @@ def generate_s3_metadata(s3_prefix: str, bucket: str, mode: str = "create") -> d
 # Script Entry Point
 # ---------------------------
 
-def main():
-    bucket = "stats121-datasets"
-    prefix = "datasets/"
+def main(s3_uri: str | None, mode: str, dry_run: bool, model: str):
+    global MODEL
+    MODEL = model
 
-    duck_logger.debug("Starting metadata generation...")
-    all_meta = generate_s3_metadata(prefix, bucket)
+    duck_logger.info(
+        f"Starting metadata generation (mode={mode}, dry_run={dry_run}, model={model})"
+    )
+    if s3_uri:
+        all_meta = generate_metadata_for_s3_uri(s3_uri, mode=mode, dry_run=dry_run)
+    else:
+        # backward-compatible default behavior
+        bucket = "stats121-datasets"
+        prefix = "datasets/"
+        all_meta = generate_s3_metadata(prefix, bucket, mode=mode, dry_run=dry_run)
 
     for dataset_name, meta in all_meta.items():
         duck_logger.debug(f"\n--- Metadata for {dataset_name} ---\n")
@@ -350,6 +421,28 @@ def main():
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('--debug', action='store_true', help='Enable debug logging')
+    parser.add_argument(
+        '--s3-uri',
+        type=str,
+        default=None,
+        help='Target S3 URI (file or prefix), e.g. s3://bucket/key.csv or s3://bucket/prefix/'
+    )
+    parser.add_argument(
+        '--mode',
+        choices=['create', 'overwrite'],
+        default='create',
+        help='create: skip existing metadata, overwrite: regenerate metadata even if it exists'
+    )
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Generate metadata but do not write .meta.json files to S3'
+    )
+    parser.add_argument(
+        '--model',
+        default=MODEL,
+        help='OpenAI model to use for metadata refinement (default: gpt-4.1-mini)'
+    )
     args = parser.parse_args()
 
     if args.debug:
@@ -359,4 +452,4 @@ if __name__ == "__main__":
 
     add_console_handler()
 
-    main()
+    main(args.s3_uri, args.mode, args.dry_run, args.model)

--- a/scripts/generate_metadata.py
+++ b/scripts/generate_metadata.py
@@ -415,8 +415,12 @@ def main(s3_uri: str | None, mode: str, dry_run: bool, model: str):
         all_meta = generate_s3_metadata(prefix, bucket, mode=mode, dry_run=dry_run)
 
     for dataset_name, meta in all_meta.items():
-        duck_logger.debug(f"\n--- Metadata for {dataset_name} ---\n")
-        duck_logger.debug(json.dumps(meta, indent=2))
+        if dry_run:
+            duck_logger.info(f"\n--- Metadata for {dataset_name} ---\n")
+            duck_logger.info(json.dumps(meta, indent=2))
+        else:
+            duck_logger.debug(f"\n--- Metadata for {dataset_name} ---\n")
+            duck_logger.debug(json.dumps(meta, indent=2))
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()

--- a/src/DOCS.md
+++ b/src/DOCS.md
@@ -8,10 +8,11 @@ Each subdirectory owns a subsystem with a focused responsibility.
 ## Operational Flow
 
 1. `main.py` loads config, initializes SQL/session state, and builds runtime dependencies.
-2. `DiscordBot` receives Discord events and forwards them to `RubberDuckApp`.
-3. `RubberDuckApp` routes admin messages to `command` workflows and duck-channel messages to `duck-orchestrator` workflows.
-4. `DuckOrchestrator` creates a thread-scoped `DuckContext`, runs the selected duck workflow, and queues conversation metadata for TA feedback.
-5. Subsystems (`gen_ai`, `armory`, `workflows`, `metrics`, `storage`, `utils`) execute behavior and persistence for that workflow.
+2. `build_armory(...)` registers configured tool functions and now adds a shared `describe_dataset` tool for any configured Python container tool.
+3. `DiscordBot` receives Discord events and forwards them to `RubberDuckApp`.
+4. `RubberDuckApp` routes admin messages to `command` workflows and duck-channel messages to `duck-orchestrator` workflows.
+5. `DuckOrchestrator` creates a thread-scoped `DuckContext`, runs the selected duck workflow, and queues conversation metadata for TA feedback.
+6. Subsystems (`gen_ai`, `armory`, `workflows`, `metrics`, `storage`, `utils`) execute behavior and persistence for that workflow.
 
 ## Boundaries
 
@@ -25,4 +26,5 @@ Each subdirectory owns a subsystem with a focused responsibility.
 ## Failure Modes and Guardrails
 
 - Runtime composition is centralized in `main.py`; update `DOCS.md` files when ownership moves to avoid drift.
+- `describe_dataset` expects exact staged filenames and should be treated as metadata retrieval, not computation.
 - Test coverage is still narrow compared to subsystem breadth, so refactors should be validated by targeted manual checks.

--- a/src/armory/DOCS.md
+++ b/src/armory/DOCS.md
@@ -7,16 +7,19 @@
 - `Armory.scrub_tools(...)` discovers `@register_tool` methods and registers them.
 - `add_tool(...)` wraps tools to accept `DuckContext`, tracks `complete_response` behavior, and stores strict function schemas.
 - `generate_function_schema(...)` derives strict JSON schema from Python type hints.
-- `PythonTools.run_code(...)` executes containerized Python, sends generated files/tables/stdout to Discord, and caches outputs.
+- `PythonTools.run_code(...)` executes containerized Python, normalizes scientific notation in stdout/stderr, sends generated files/tables/stdout to Discord, and caches outputs.
+- `send_table(...)` now renders numeric cells as plain decimal strings (rounded/trimmed) and disables markdown numeric parsing to preserve formatting.
+- `DatasetTools.describe_dataset(...)` returns full dataset metadata by exact staged filename and reports valid filenames when no match exists.
 - `TalkTool` provides conversation tools (`talk_to_user`, send/receive file/message, conclude).
 
 ## Dependencies
 
-- Depends on `utils.python_exec_container` for execution sandbox behavior.
+- Depends on `utils.python_exec_container` for execution sandbox behavior and dataset metadata lookup.
 - Depends on cache implementations in `tool_cache.py` (`InMemoryToolCache`, `SqlToolCache`, `SemanticCacheKeyBuilder`).
 
 ## Failure Modes and Guardrails
 
 - Tool parameters must be type-annotated for schema generation.
 - Duplicate tool names overwrite earlier registrations.
+- `DatasetTools.describe_dataset(...)` requires exact filename matches.
 - `SqlToolCache` requires a valid SQLAlchemy bind at initialization.

--- a/src/armory/python_tools.py
+++ b/src/armory/python_tools.py
@@ -115,7 +115,7 @@ class PythonTools:
         if self._tool_cache and self._cache_key_builder:
             cache_key = self._cache_key_builder.build_cache_key(user_intent, code)
             key = self._tool_cache.get_key(cache_key)
-            duck_logger.debug(f"\nCache key:\n{key}")
+            duck_logger.debug(f"Cache key: {key}")
 
             if self._tool_cache.check_if_cached(key):
                 duck_logger.debug(f" Cache HIT ".center(20, '-'))
@@ -180,3 +180,45 @@ class PythonTools:
             output = ConcludesResponse(output)
 
         return output
+
+
+class DatasetTools:
+    def __init__(self, containers: list[PythonExecContainer]):
+        self._containers = containers
+
+    def get_resource_metadata(self) -> str:
+        lines = ["\n### Available Files:"]
+        for container in self._containers:
+            for dataset in container.get_dataset_inventory():
+                lines.append(f"\nDataset file path: {dataset['path']}")
+                dataset_name = dataset.get("dataset_name", dataset["filename"])
+                lines.append(f"Dataset name: {dataset_name}")
+        return "\n".join(lines)
+
+    async def describe_dataset(self, ctx: DuckContext, dataset_name: str) -> str:
+        """
+        Returns the full dataset description for an exact dataset filename match.
+        Use the exact filename shown in the available dataset list.
+        """
+        duck_logger.debug(f"describe_dataset called with dataset_name={dataset_name!r}")
+        for container in self._containers:
+            description = container.describe_dataset(dataset_name)
+            if description:
+                duck_logger.debug(f"\n{description}")
+                return description
+
+        available = sorted({
+            filename
+            for container in self._containers
+            for filename in container.get_dataset_filenames()
+        })
+        if not available:
+            duck_logger.debug(f"describe_dataset no datasets available for dataset_name={dataset_name!r}")
+            return "No datasets are currently available."
+
+        message = (
+            f"Dataset '{dataset_name}' not found. "
+            f"Available dataset filenames: {', '.join(available)}"
+        )
+        duck_logger.debug(f"describe_dataset no match for dataset_name={dataset_name!r}; {message}")
+        return message

--- a/src/armory/python_tools.py
+++ b/src/armory/python_tools.py
@@ -1,4 +1,6 @@
 import io
+import re
+from decimal import Decimal, InvalidOperation
 import pandas as pd
 
 from ..utils.protocols import ToolCache, CacheKeyBuilder
@@ -6,6 +8,32 @@ from ..utils.config_types import DuckContext
 from ..utils.logger import duck_logger
 from ..utils.protocols import SendMessage, ConcludesResponse
 from ..utils.python_exec_container import PythonExecContainer, is_image, is_table, FileResult
+
+
+_SCI_NOTATION_PATTERN = re.compile(
+    r"(?<![\w.])([+-]?(?:\d+(?:\.\d*)?|\.\d+)[eE][+-]?\d+)(?![\w.])"
+)
+
+
+def _to_plain_decimal(token: str) -> str:
+    try:
+        value = Decimal(token)
+    except InvalidOperation:
+        return token
+
+    if not value.is_finite():
+        return token
+
+    formatted = format(value, "f")
+    if "." in formatted:
+        formatted = formatted.rstrip("0").rstrip(".")
+    if formatted in {"", "-0", "+0"}:
+        return "0"
+    return formatted
+
+
+def _remove_scientific_notation(text: str) -> str:
+    return _SCI_NOTATION_PATTERN.sub(lambda m: _to_plain_decimal(m.group(1)), text)
 
 
 def _estimate_column_widths(df, sample_rows=20):
@@ -61,7 +89,7 @@ def _clean_stdout(stdout: str, files: dict[str, FileResult]) -> str:
         filtered_lines.append(line)
 
     stdout = "\n".join(filtered_lines).strip()
-    return stdout
+    return _remove_scientific_notation(stdout)
 
 
 async def send_table(
@@ -75,7 +103,7 @@ async def send_table(
     table_chunks = []
 
     for i in range(0, table.shape[1], col_chunk):
-        md_table = table.iloc[:, i:i + col_chunk].to_markdown()
+        md_table = table.iloc[:, i:i + col_chunk].to_markdown(floatfmt=".15f")
         table_chunk = f"```\n{md_table}\n```"
         table_chunks.append(table_chunk)
         await send_message(channel_id, table_chunk)
@@ -132,7 +160,7 @@ class PythonTools:
         results = await self._container.run_code(code)
 
         stdout = results.get('stdout').strip()
-        stderr = results.get('stderr').strip()
+        stderr = _remove_scientific_notation(results.get('stderr').strip())
         files = results.get('files', {})
 
         # log created files

--- a/src/armory/python_tools.py
+++ b/src/armory/python_tools.py
@@ -195,14 +195,14 @@ class DatasetTools:
                 lines.append(f"Dataset name: {dataset_name}")
         return "\n".join(lines)
 
-    async def describe_dataset(self, ctx: DuckContext, dataset_name: str) -> str:
+    async def describe_dataset(self, ctx: DuckContext, dataset_filename: str) -> str:
         """
         Returns the full dataset description for an exact dataset filename match.
-        Use the exact filename shown in the available dataset list.
+        Use the exact filename shown in the available dataset list (not Dataset Name).
         """
-        duck_logger.debug(f"describe_dataset called with dataset_name={dataset_name!r}")
+        duck_logger.debug(f"describe_dataset called with dataset_name={dataset_filename!r}")
         for container in self._containers:
-            description = container.describe_dataset(dataset_name)
+            description = container.describe_dataset(dataset_filename)
             if description:
                 duck_logger.debug(f"\n{description}")
                 return description
@@ -213,12 +213,12 @@ class DatasetTools:
             for filename in container.get_dataset_filenames()
         })
         if not available:
-            duck_logger.debug(f"describe_dataset no datasets available for dataset_name={dataset_name!r}")
+            duck_logger.debug(f"describe_dataset no datasets available for dataset_name={dataset_filename!r}")
             return "No datasets are currently available."
 
         message = (
-            f"Dataset '{dataset_name}' not found. "
+            f"Dataset '{dataset_filename}' not found. "
             f"Available dataset filenames: {', '.join(available)}"
         )
-        duck_logger.debug(f"describe_dataset no match for dataset_name={dataset_name!r}; {message}")
+        duck_logger.debug(f"describe_dataset no match for dataset_name={dataset_filename!r}; {message}")
         return message

--- a/src/armory/python_tools.py
+++ b/src/armory/python_tools.py
@@ -2,6 +2,7 @@ import io
 import re
 from decimal import Decimal, InvalidOperation
 import pandas as pd
+from pandas.api.types import is_numeric_dtype
 
 from ..utils.protocols import ToolCache, CacheKeyBuilder
 from ..utils.config_types import DuckContext
@@ -34,6 +35,23 @@ def _to_plain_decimal(token: str) -> str:
 
 def _remove_scientific_notation(text: str) -> str:
     return _SCI_NOTATION_PATTERN.sub(lambda m: _to_plain_decimal(m.group(1)), text)
+
+
+def _format_rounded_decimal(value: float, places: int = 4) -> str:
+    formatted = format(float(value), f".{places}f")
+    formatted = formatted.rstrip("0").rstrip(".")
+    return formatted if formatted else "0"
+
+
+def _format_table_values(table: pd.DataFrame) -> pd.DataFrame:
+    formatted_table = table.copy()
+    for col in formatted_table.columns:
+        if not is_numeric_dtype(formatted_table[col]):
+            continue
+        formatted_table[col] = formatted_table[col].map(
+            lambda value: _format_rounded_decimal(value, 4) if pd.notna(value) else ""
+        )
+    return formatted_table
 
 
 def _estimate_column_widths(df, sample_rows=20):
@@ -98,12 +116,12 @@ async def send_table(
         table: pd.DataFrame,
         max_rows: int = 100,
 ) -> list[str]:
-    table = table.head(max_rows)
+    table = _format_table_values(table.head(max_rows))
     col_chunk = _determine_col_chunk(table)
     table_chunks = []
 
     for i in range(0, table.shape[1], col_chunk):
-        md_table = table.iloc[:, i:i + col_chunk].to_markdown(floatfmt=".15f")
+        md_table = table.iloc[:, i:i + col_chunk].to_markdown(disable_numparse=True)
         table_chunk = f"```\n{md_table}\n```"
         table_chunks.append(table_chunk)
         await send_message(channel_id, table_chunk)

--- a/src/main.py
+++ b/src/main.py
@@ -15,7 +15,7 @@ from .armory.tool_cache import InMemoryToolCache, SemanticCacheKeyBuilder, SqlTo
 from .workflows.registration import Registration
 from .workflows.assignment_feedback_workflow import AssignmentFeedbackWorkflow
 from .utils.python_exec_container import build_containers, PythonExecContainer
-from .armory.python_tools import PythonTools
+from .armory.python_tools import PythonTools, DatasetTools
 from .armory.armory import Armory
 from .armory.talk_tool import TalkTool
 from .bot.discord_bot import DiscordBot
@@ -294,12 +294,14 @@ def build_armory(
 ) -> tuple[Armory, TalkTool, list[ToolCache]]:
     armory = Armory(send_message)
     tool_caches: list[ToolCache] = []
+    container_names_for_python_tools: set[str] = set()
 
     # setup tools
     config_tools = config.get("tools", [])
     for tool_name, tool_config in config_tools.items():
         if tool_config['type'] == 'container_exec':
             container_name = tool_config['container']
+            container_names_for_python_tools.add(container_name)
             cache_settings = _get_tool_cache_settings(tool_config)
             tool_cache = None
             cache_key_builder = None
@@ -314,14 +316,24 @@ def build_armory(
                 tool_cache,
                 cache_key_builder
             )
-            amended_description = (
-                    tool_config.get('description', python_tools.run_code.__doc__)
-                    + '\n'
-                    + containers[container_name].get_resource_metadata()
-            )
+            amended_description = tool_config.get('description', python_tools.run_code.__doc__)
             armory.add_tool(python_tools.run_code, name=tool_name, description=amended_description)
         else:
             duck_logger.warning(f"Unsupported tool type: {tool_config['type']}")
+
+    dataset_containers = [containers[name] for name in sorted(container_names_for_python_tools)]
+    if dataset_containers:
+        dataset_tools = DatasetTools(dataset_containers)
+        describe_dataset_description = (
+            "Returns the full description for a dataset by exact dataset filename.\n"
+            "Use this when you need full column-level metadata."
+            + dataset_tools.get_resource_metadata()
+        )
+        armory.add_tool(
+            dataset_tools.describe_dataset,
+            name="describe_dataset",
+            description=describe_dataset_description
+        )
 
     talk_tool = TalkTool(send_message)
     armory.scrub_tools(talk_tool)
@@ -459,7 +471,7 @@ if __name__ == '__main__':
     # Set debug environment variable if debug flag is set
     if args.debug:
         duck_logger.setLevel(logging.DEBUG)
-        quest_logger.setLevel(logging.DEBUG)
+        # quest_logger.setLevel(logging.DEBUG)
     else:
         duck_logger.setLevel(logging.INFO)
         quest_logger.setLevel(logging.INFO)

--- a/src/utils/DOCS.md
+++ b/src/utils/DOCS.md
@@ -8,6 +8,8 @@
 - `logger.py` sets structured log formatting and optional admin-channel log forwarding.
 - `persistent_queue.py` provides context-managed queue persistence backed by blob storage.
 - `python_exec_container.py` manages Docker container lifecycle, resource staging, code execution, and artifact extraction.
+- `python_exec_container.py` records staged dataset metadata (`filename`, resolved dataset name, full description) and provides exact-filename lookup helpers used by armory dataset tools.
+- The execution wrapper configures numpy/pandas display formatting to suppress scientific notation in typical numeric output.
 - `cache_cleaner.py` and `feedback_notifier.py` run scheduled maintenance/notification loops.
 - `zip_utils.py` exports table-like data as zipped CSV for command responses.
 
@@ -21,3 +23,4 @@
 - Docker-dependent execution fails fast when daemon connectivity is unavailable.
 - Queue persistence requires entering/exiting `PersistentQueue` contexts to rehydrate/stash state correctly.
 - Config include cycles are rejected during load.
+- Dataset description lookup is exact by staged filename; callers should disambiguate before lookup.

--- a/src/utils/python_exec_container.py
+++ b/src/utils/python_exec_container.py
@@ -299,7 +299,7 @@ class PythonExecContainer:
                 import pandas as pd
 
                 def _plain_float(value):
-                    formatted = format(float(value), ".15f")
+                    formatted = format(float(value), ".4f")
                     formatted = formatted.rstrip("0").rstrip(".")
                     return formatted if formatted else "0"
 

--- a/src/utils/python_exec_container.py
+++ b/src/utils/python_exec_container.py
@@ -293,6 +293,24 @@ class PythonExecContainer:
 
             outdir = Path({path!r})  # full container path for outputs
 
+            # ===== Configure numeric display (no scientific notation) ===== #
+            try:
+                import numpy as np
+                import pandas as pd
+
+                def _plain_float(value):
+                    formatted = format(float(value), ".15f")
+                    formatted = formatted.rstrip("0").rstrip(".")
+                    return formatted if formatted else "0"
+
+                np.set_printoptions(
+                    suppress=True,
+                    formatter={{"float_kind": _plain_float}}
+                )
+                pd.set_option("display.float_format", _plain_float)
+            except Exception:
+                pass
+
             # ===== Patch matplotlib to auto-save metadata ===== #
             try:
                 import matplotlib.pyplot as plt

--- a/src/utils/python_exec_container.py
+++ b/src/utils/python_exec_container.py
@@ -91,10 +91,24 @@ class PythonExecContainer:
 
     def _stage_file(self, target_path: str, dataset: DatasetInfo):
         self._write_file(dataset.filename, dataset.data, target_path)
+        dataset_name = self._extract_dataset_name(dataset.description, dataset.filename)
         self._resource_metadata.append({
+            "filename": dataset.filename,
             "path": os.path.join(target_path, dataset.filename),
-            "description": dataset.description,
+            "dataset_name": dataset_name,
+            "full_description": dataset.description,
         })
+
+    @staticmethod
+    def _extract_dataset_name(description: str, fallback_filename: str) -> str:
+        prefix = "Dataset name:"
+        for line in description.splitlines():
+            stripped = line.strip()
+            if stripped.startswith(prefix):
+                value = stripped[len(prefix):].strip()
+                if value:
+                    return value
+        return fallback_filename
 
     def _stage_files(self):
         for resource_info in self._resource_data:
@@ -400,21 +414,38 @@ class PythonExecContainer:
                 "files": {}
             }
 
-    def get_resource_metadata(self) -> str:
-        """Return prompt content describing each file copied into the container"""
-        lines = ["\n### Available Files:"]
-
+    def describe_dataset(self, dataset_name: str) -> str | None:
+        """Return full metadata for a dataset matched by exact staged filename."""
         for resource in self._resource_metadata:
-            path = resource.get("path", "unknown")
-            description = resource.get("description", "")
+            if resource.get("filename") == dataset_name:
+                full_description = resource.get("full_description", "").strip()
+                if full_description:
+                    return full_description
+                short_name = resource.get("dataset_name", dataset_name)
+                return f"Dataset name: {short_name}"
+        return None
 
-            lines.append(f"\nDataset file path: {path}")
-            if description:
-                lines.append(description)
+    def get_dataset_filenames(self) -> list[str]:
+        return sorted(
+            resource.get("filename", "")
+            for resource in self._resource_metadata
+            if resource.get("filename")
+        )
 
-        prompt_add_on = "\n".join(lines)
-        duck_logger.debug(f"Resource descriptions to add to prompt:\n{prompt_add_on}")
-        return prompt_add_on
+    def get_dataset_inventory(self) -> list[dict[str, str]]:
+        inventory = []
+        for resource in self._resource_metadata:
+            filename = resource.get("filename")
+            path = resource.get("path")
+            dataset_name = resource.get("dataset_name")
+            if not filename or not path:
+                continue
+            inventory.append({
+                "filename": filename,
+                "path": path,
+                "dataset_name": dataset_name or filename,
+            })
+        return inventory
 
 
 def build_containers(config: Config) -> dict[str, PythonExecContainer]:

--- a/tests/DOCS.md
+++ b/tests/DOCS.md
@@ -1,12 +1,14 @@
 ## Purpose
 
-`tests/` currently provides lightweight regression checks for SQL metrics persistence behavior.
+`tests/` provides lightweight regression checks for SQL metrics persistence and Python tool output formatting behavior.
 
 ## Operational Flow
 
 - `test_sql_metric_handlers.py` validates insert/read paths for `messages`, `usage`, and `feedback` via in-memory SQLite.
+- `test_python_tools_formatting.py` validates numeric table formatting, blank handling, and scientific-notation suppression in rendered tool output.
 - `conftest.py` injects a minimal `quest` module shim so tests can import project modules without full runtime dependencies.
 
 ## Failure Modes and Guardrails
 
 - Test coverage is intentionally narrow; most runtime subsystems are currently untested in this directory.
+- Formatting tests assert string-level output contracts, so prompt/runtime formatting changes may require coordinated test updates.

--- a/tests/test_python_tools_formatting.py
+++ b/tests/test_python_tools_formatting.py
@@ -1,0 +1,80 @@
+import pandas as pd
+import sys
+import types
+import asyncio
+
+
+boto3_stub = types.ModuleType("boto3")
+boto3_stub.client = lambda *_args, **_kwargs: types.SimpleNamespace()
+sys.modules.setdefault("boto3", boto3_stub)
+
+botocore_stub = types.ModuleType("botocore")
+botocore_exceptions_stub = types.ModuleType("botocore.exceptions")
+
+
+class _ClientError(Exception):
+    pass
+
+
+botocore_exceptions_stub.ClientError = _ClientError
+botocore_stub.exceptions = botocore_exceptions_stub
+sys.modules.setdefault("botocore", botocore_stub)
+sys.modules.setdefault("botocore.exceptions", botocore_exceptions_stub)
+
+from src.armory.python_tools import _format_table_values, send_table
+
+
+def test_format_table_values_rounds_and_trims_numeric_columns():
+    table = pd.DataFrame(
+        {
+            "value": [28.300000000001, 1.23456, 2.0],
+            "label": ["a", "b", "c"],
+        }
+    )
+
+    formatted = _format_table_values(table)
+
+    assert formatted["value"].tolist() == ["28.3", "1.2346", "2"]
+    assert formatted["label"].tolist() == ["a", "b", "c"]
+
+
+def test_format_table_values_keeps_blank_for_missing_numeric_values():
+    table = pd.DataFrame({"value": [1.2, None]})
+
+    formatted = _format_table_values(table)
+
+    assert formatted["value"].tolist() == ["1.2", ""]
+
+
+def test_format_table_values_expands_scientific_notation_and_rounds():
+    table = pd.DataFrame({"value": [1.23016e+07]})
+
+    formatted = _format_table_values(table)
+
+    assert formatted["value"].tolist() == ["12301600"]
+
+
+def test_send_table_does_not_reintroduce_scientific_notation():
+    table = pd.DataFrame(
+        {
+            "conf_low": [-3.71812e08, -40746, 99701.2],
+            "conf_high": [-1.97874e08, 332304, 2.45405e06],
+        }
+    )
+    sent_messages = []
+
+    async def _send_message(_channel_id, message=None, file=None):
+        if message is not None:
+            sent_messages.append(message)
+        if file is not None:
+            sent_messages.append(str(file))
+
+    asyncio.run(send_table(_send_message, 123, table))
+
+    rendered = "\n".join(sent_messages)
+    assert "-3.71812e+08" not in rendered
+    assert "-1.97874e+08" not in rendered
+    assert "2.45405e+06" not in rendered
+    assert "-371812000" in rendered
+    assert "-197874000" in rendered
+    assert "2454050" in rendered


### PR DESCRIPTION
# Biggest Changes
- New `describe-dataset` tool that significantly reduced context for `stats-duck`
    - Only loads full metadata into context when needed
    - Very noticeable increase in performance
- Streamlined `generate_metadata.py`
- Created metadata file for `s3://byu-cms-metrics/cs-merged-dashboard.csv`

## Standard Stats Duck Improvements:
(At Matt's request)
- Removed scientific notation from all output
- Always label numeric output
- Return just the coefficient table instead of full regression summary
- simplify white test output
- give it the `conclude_conversation` tool