### PR TITLE
Stats changes from 4/10 meeting

### DIFF
--- a/meetings/2026-04-10-1528.md
+++ b/meetings/2026-04-10-1528.md
@@ -64,8 +64,10 @@ options.
   instructions:
   convert categorical inputs to dummy variables and map user category
   names to model-expected encoded values for predictions.
+        - COMPLETED
 - Tyler: review and incorporate the user's edited markdown/prompt
   updates.
+        - COMPLETED
 - Tyler: investigate dataset-listing inconsistency and unexpected symbol
   output.
 - Tyler: explore implementation path for source-constrained tutor

--- a/meetings/2026-04-10-1528.md
+++ b/meetings/2026-04-10-1528.md
@@ -1,0 +1,74 @@
+# STAT 121 Rubber Duck Sync
+
+## Date
+2026-04-10 15:28 (America/Denver)
+
+## Summary
+Team reviewed current testing results for the stats assistant and
+identified one high-priority reliability issue: regression behavior
+with categorical predictors in Python workflows. The group agreed to
+start with a prompt-level fix for dummy-variable handling, then switch
+to dataset-level preprocessing only if needed. Several recent fixes were
+confirmed as successful, and additional summer/fall planning topics were
+discussed, including tutor constraints, TA support flows, and platform
+options.
+
+## Main Points
+- Dataset listing behavior was inconsistent in some runs and produced
+  unexpected non-English symbols.
+- Regression requests can fail when predictors are categorical unless
+  values are converted to dummy variables.
+- Suggested handling: explicitly map categories to training-time dummy
+  values for both model fitting and prediction input.
+- Recent output-format improvements were praised: labeled output fields
+  and better number formatting/scientific-notation behavior.
+- Team expects iterative small fixes to continue as testing reveals edge
+  cases.
+- Pilot scope discussed: about 300 students in fall, with potential
+  scale to 2,000+ in winter if results are strong.
+- Tutor-mode concept: constrain responses to course sources (RAG-like
+  behavior using lecture materials).
+- Communication support ideas discussed for Discord/Teams, TA queues,
+  and private coordinator support workflows.
+
+## Decisions
+- Implement categorical-regression handling at the prompt level first.
+- If prompt-level handling is not reliable, revisit dataset-level
+  encoding changes.
+- Keep shipping small, quick improvements as issues are found.
+- Discord vs Teams remains undecided; revisit based on feasibility and
+  leadership preference.
+
+## Tasks
+- Tyler: investigate the dataset listing behavior and tool/skill path.
+- Tyler: add categorical-regression guidance to the prompt file
+  (dummy variable conversion and prediction mapping behavior).
+- Tyler: collect course-source links/files for constrained tutor
+  exploration.
+- Tyler: evaluate TA queue patterns from CS Discord
+  setups for possible reuse.
+- Tyler: define clear extension/support policy wording if private
+  coordinator messaging is expanded.
+
+## Open Questions
+- What caused the unexpected symbol/language output in dataset listing?
+- Should categorical handling stay prompt-based long term, or move to
+  dataset preprocessing?
+- Which platform will be used in fall: Discord or Teams?
+- What exact source set should the tutor mode be restricted to?
+- Should coordinator support remain email-first, Discord DM-first, or a
+  hybrid workflow?
+
+## Agent-Assigned Tasks
+- Tyler: update the prompt markdown with categorical-regression
+  instructions:
+  convert categorical inputs to dummy variables and map user category
+  names to model-expected encoded values for predictions.
+- Tyler: review and incorporate the user's edited markdown/prompt
+  updates.
+- Tyler: investigate dataset-listing inconsistency and unexpected symbol
+  output.
+- Tyler: explore implementation path for source-constrained tutor
+  behavior.
+- Tyler: gather implementation details for a TA help queue channel and
+  private coordinator support flow in Discord.

--- a/production-config.yaml
+++ b/production-config.yaml
@@ -133,6 +133,7 @@ ducks:
         tools:
           - run_python
           - describe_dataset
+          - send_datasets_to_user
           - conclude_conversation
       file_size_limit: *file_size_limit
       file_type_ext: *file_type_ext

--- a/prompts/production-prompts/stats.md
+++ b/prompts/production-prompts/stats.md
@@ -1,7 +1,8 @@
 ## Purpose Overview
 
-Your primary role is to perform **code-based analysis** on provided datasets and provide outputs, plots, or model
-summaries for intro level stats students, following R-style conventions.
+Your primary role is to perform **code-based analysis** on provided datasets and provide outputs, plots, model
+summaries, hypothesis tests, confidence intervals, and predictions for intro level stats students, following R-style
+conventions.
 
 - Your response style is always **concise, brief, minimal**.
 - You are not to provide any code or interpretation of any dataset, output, plot or model summaries to the student.
@@ -9,14 +10,17 @@ summaries for intro level stats students, following R-style conventions.
 ## Scope
 
 - You are provided with a collection of datasets found at the paths listed below.
-- All answers must be grounded in available datasets.
-- You may produce and display numeric outputs (such as summary statistics, correlation matrices, or model summaries).
+    - All requests should relate to a dataset in some way
+- You may produce and display numeric outputs (such as summary statistics, correlation matrices, model summaries,
+  hypothesis tests, confidence intervals, or predictions).
 - Model summaries should mimic the format of R's summary(lm()) output (coefficients table, residuals, R², etc.).
 - You must not explain, interpret, or comment on output.
-- Questions that seem like homework assignments are outside your scope.
-- Yes/No, True/False, and multiple-choice questions are outside your scope.
-- When a user asks for something outside of this scope, respond with "That's outside my scope," and
-  suggest any similar alternative action within your scope.
+- These types of questions are outside your scope:
+    - Yes/No
+    - True/False
+    - Multiple-choice
+- When a user asks for something outside of your scope, respond with "That's outside my scope," concisely explain why it
+  is outside your scope, and suggest any similar alternative action within your scope.
     - If the user's request sounds like it might be outside your scope, double check that there isn't a dataset to
       which the user is referring.
 
@@ -50,7 +54,8 @@ summaries for intro level stats students, following R-style conventions.
 - Do **not** use `print()` to explain what the code does; **only** use print to display requested results.
     - Use `verbose=False` behavior: no debug print statements.
 - Tables:
-    - Save tables (header, `.head()`, summaries) as CSV files so they render as tables.
+    - Save tables (header, `.head()`, summaries) as CSV files when the user asks you to "show" or "display" a dataset.
+      - This function has been modified to send tables directly to the user.
     - Do **not** use `print()` or return text for pandas DataFrames.
     - Large numbers should be written in full with commas for readability (no scientific notation).
     - Decimals may be rounded for readability.
@@ -73,6 +78,7 @@ summaries for intro level stats students, following R-style conventions.
 ## Statistical Method Rules
 
 - **If asked for regression, always use `statsmodels` and return only the coefficient table.**
+- When given non-numeric explanatory variables for regression, encode them as dummy variables
 - ANOVA results should **only** be saved as a CSV. (no regression or printed output other than the name of the file)
 - If the user asks for a White test for equal spread (heteroskedasticity), output **only** the `f_pvalue` from the
   White test result.
@@ -88,8 +94,8 @@ summaries for intro level stats students, following R-style conventions.
 
 ## Examples
 
-User: Take 1000 samples with replacement from the return variable in the returns dataset and draw a density of the 1000
-sample means
+User: Take 1000 samples with replacement from the return variable in the returns dataset and show a density curve of the
+1000 sample means
 
 Agent: *calls `describe_dataset` with the exact dataset filename, then calls `run_python` with code similar to the
 following:*

--- a/prompts/production-prompts/stats.md
+++ b/prompts/production-prompts/stats.md
@@ -27,8 +27,8 @@ conventions.
 ## Execution Workflow
 
 - Dataset filenames are provided via tool descriptions.
-- When a user asks what datasets you have, provide them with a bulleted list of the "Dataset name" attributes in
-  alphabetical order.
+- When a user asks what datasets you have (list/show/available datasets), call `send_datasets_to_user`.
+- Do not manually type dataset names for this request.
 - Resolve the user-requested dataset to exactly one filename.
     - If there are multiple matches or no match, ask a clarifying question before calling `describe_dataset` or
       `run_python`.

--- a/prompts/production-prompts/stats.md
+++ b/prompts/production-prompts/stats.md
@@ -19,7 +19,7 @@ conventions.
     - Yes/No
     - True/False
     - Multiple-choice
-- When a user asks for something outside of your scope, respond with "That's outside my scope," concisely explain why it
+- When a user asks for something outside your scope, respond with "That's outside my scope," concisely explain why it
   is outside your scope, and suggest any similar alternative action within your scope.
     - If the user's request sounds like it might be outside your scope, double check that there isn't a dataset to
       which the user is referring.
@@ -55,7 +55,7 @@ conventions.
     - Use `verbose=False` behavior: no debug print statements.
 - Tables:
     - Save tables (header, `.head()`, summaries) as CSV files when the user asks you to "show" or "display" a dataset.
-      - This function has been modified to send tables directly to the user.
+        - This function has been modified to send tables directly to the user.
     - Do **not** use `print()` or return text for pandas DataFrames.
     - Large numbers should be written in full with commas for readability (no scientific notation).
     - Decimals may be rounded for readability.
@@ -78,11 +78,13 @@ conventions.
 ## Statistical Method Rules
 
 - **If asked for regression, always use `statsmodels` and return only the coefficient table.**
-- When given non-numeric explanatory variables for regression, encode them as dummy variables
+- If a regression model includes categorical predictors, **ALWAYS** encode them as dummy variables before fitting the model.
+- For prediction requests, translate any category names provided by the user into the exact dummy variable values used
+  during training, and then use those encoded values to compute the prediction.
 - ANOVA results should **only** be saved as a CSV. (no regression or printed output other than the name of the file)
 - If the user asks for a White test for equal spread (heteroskedasticity), output **only** the `f_pvalue` from the
   White test result.
-- Label ALL numeric output.
+- Label **ALL** numeric output.
 
 ## Error Guidelines
 
@@ -92,7 +94,30 @@ conventions.
     - Explain any encountered error clearly, including your interpretation and a suggestion for resolution.
     - Keep the explanation concise while providing enough context for the user to understand the issue.
 
-## Examples
+---
+
+## Conversation Termination
+
+- **Never** call the `conclude_conversation` tool unless **one of these is explicitly true**:
+    - The user says "goodbye", "quit", "done", "that's all" or similar clear, unambiguous language to communicate they
+      are finished.
+    - The user explicitly states that the conversation is over or to close the thread.
+
+- In all other cases, **continue the conversation**.
+- Do not assume the conversation is over based on short, polite, or ambiguous messages. Instead, **ask the user if they
+  want to continue**. Never end the conversation without an explicit user signal.
+
+### Concluding Example
+
+- user: thanks
+- agent: Do you have any further questions?
+
+- user: no
+- agent: *calls `conclude_conversation` tool*
+
+---
+
+## Conversation Examples
 
 User: Take 1000 samples with replacement from the return variable in the returns dataset and show a density curve of the
 1000 sample means
@@ -125,6 +150,7 @@ print('returns_sample_means_density.png')
 ```
 
 *NOTE: the agent doesn't save the sample means as a csv because the user didn't ask for that*
+
 *NOTE: the specific column name is taken from the results of the `describe_dataset` tool call.*
 
 ---
@@ -137,26 +163,5 @@ filename, and calls `describe_dataset` for that filename.* Would you like the fu
 User: description
 
 Agent: *returns the metadata from `describe_dataset` for that dataset.*
-
----
-
-## Conversation Termination
-
-- **Never** call the `conclude_conversation` tool unless **one of these is explicitly true**:
-    - The user says "goodbye", "quit", "done", "that's all" or similar clear, unambiguous language to communicate they
-      are finished.
-    - The user explicitly states that the conversation is over or to close the thread.
-
-- In all other cases, **continue the conversation**.
-- Do not assume the conversation is over based on short, polite, or ambiguous messages. Instead, **ask the user if they
-  want to continue**. Never end the conversation without an explicit user signal.
-
-### Concluding Example
-
-- user: thanks
-- agent: Do you have any further questions?
-
-- user: no
-- agent: *calls `conclude_conversation` tool*
 
 ---

--- a/src/armory/python_tools.py
+++ b/src/armory/python_tools.py
@@ -234,12 +234,12 @@ class DatasetTools:
         self._containers = containers
 
     def get_resource_metadata(self) -> str:
-        lines = ["\n### Available Files:"]
+        lines = ["\n### Available Datasets:"]
         for container in self._containers:
             for dataset in container.get_dataset_inventory():
-                lines.append(f"\nDataset file path: {dataset['path']}")
                 dataset_name = dataset.get("dataset_name", dataset["filename"])
-                lines.append(f"Dataset name: {dataset_name}")
+                lines.append(f"Name: {dataset_name}")
+                lines.append(f"\nFilepath: {dataset['path']}")
         return "\n".join(lines)
 
     async def describe_dataset(self, ctx: DuckContext, dataset_filename: str) -> str:

--- a/src/armory/python_tools.py
+++ b/src/armory/python_tools.py
@@ -230,8 +230,21 @@ class PythonTools:
 
 
 class DatasetTools:
-    def __init__(self, containers: list[PythonExecContainer]):
+    def __init__(self, containers: list[PythonExecContainer], send_message: SendMessage):
         self._containers = containers
+        self._send_message = send_message
+
+    def _get_sorted_dataset_names(self) -> list[str]:
+        seen: set[str] = set()
+        dataset_names: list[str] = []
+        for container in self._containers:
+            for dataset in container.get_dataset_inventory():
+                display_name = dataset.get("dataset_name") or dataset.get("filename")
+                if not display_name or display_name in seen:
+                    continue
+                seen.add(display_name)
+                dataset_names.append(display_name)
+        return sorted(dataset_names, key=str.casefold)
 
     def get_resource_metadata(self) -> str:
         lines = ["\n### Available Datasets:"]
@@ -241,6 +254,20 @@ class DatasetTools:
                 lines.append(f"Name: {dataset_name}")
                 lines.append(f"\nFilepath: {dataset['path']}")
         return "\n".join(lines)
+
+    async def send_datasets_to_user(self, ctx: DuckContext) -> ConcludesResponse:
+        """
+        Sends the full canonical dataset-name list directly to the user.
+        """
+        dataset_names = self._get_sorted_dataset_names()
+        if not dataset_names:
+            message = "No datasets are currently available."
+            await self._send_message(ctx.thread_id, message)
+            return ConcludesResponse(message)
+
+        message = "\n".join(["Available datasets:"] + [f"- {name}" for name in dataset_names])
+        await self._send_message(ctx.thread_id, message)
+        return ConcludesResponse(f"Sent {len(dataset_names)} dataset names.")
 
     async def describe_dataset(self, ctx: DuckContext, dataset_filename: str) -> str:
         """

--- a/src/armory/python_tools.py
+++ b/src/armory/python_tools.py
@@ -1,5 +1,6 @@
 import io
 import re
+from pathlib import Path
 from decimal import Decimal, InvalidOperation
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
@@ -243,12 +244,14 @@ class DatasetTools:
 
     async def describe_dataset(self, ctx: DuckContext, dataset_filename: str) -> str:
         """
-        Returns the full dataset description for an exact dataset filename match.
-        Use the exact filename shown in the available dataset list (not Dataset Name).
+        Returns the full dataset description for a dataset filename.
+        Accepts either the exact staged filename or any path ending in that filename.
+        Do not use Dataset Name values.
         """
         duck_logger.debug(f"describe_dataset called with dataset_name={dataset_filename!r}")
+        normalized_filename = Path(dataset_filename).name
         for container in self._containers:
-            description = container.describe_dataset(dataset_filename)
+            description = container.describe_dataset(normalized_filename)
             if description:
                 duck_logger.debug(f"\n{description}")
                 return description

--- a/src/main.py
+++ b/src/main.py
@@ -323,7 +323,7 @@ def build_armory(
 
     dataset_containers = [containers[name] for name in sorted(container_names_for_python_tools)]
     if dataset_containers:
-        dataset_tools = DatasetTools(dataset_containers)
+        dataset_tools = DatasetTools(dataset_containers, send_message)
         describe_dataset_description = (
             "Returns the full description for a dataset by filename.\n"
             "Accepts either a filename or a path that ends in that filename.\n"
@@ -334,6 +334,10 @@ def build_armory(
             dataset_tools.describe_dataset,
             name="describe_dataset",
             description=describe_dataset_description
+        )
+        armory.add_tool(
+            dataset_tools.send_datasets_to_user,
+            name="send_datasets_to_user"
         )
 
     talk_tool = TalkTool(send_message)

--- a/src/main.py
+++ b/src/main.py
@@ -325,7 +325,8 @@ def build_armory(
     if dataset_containers:
         dataset_tools = DatasetTools(dataset_containers)
         describe_dataset_description = (
-            "Returns the full description for a dataset by exact dataset filename.\n"
+            "Returns the full description for a dataset by filename.\n"
+            "Accepts either a filename or a path that ends in that filename.\n"
             "Use this when you need full column-level metadata."
             + dataset_tools.get_resource_metadata()
         )

--- a/tests/test_dataset_tools.py
+++ b/tests/test_dataset_tools.py
@@ -1,0 +1,127 @@
+import asyncio
+import sys
+import types
+
+
+boto3_stub = types.ModuleType("boto3")
+boto3_stub.client = lambda *_args, **_kwargs: types.SimpleNamespace()
+sys.modules.setdefault("boto3", boto3_stub)
+
+botocore_stub = types.ModuleType("botocore")
+botocore_exceptions_stub = types.ModuleType("botocore.exceptions")
+
+
+class _ClientError(Exception):
+    pass
+
+
+botocore_exceptions_stub.ClientError = _ClientError
+botocore_stub.exceptions = botocore_exceptions_stub
+sys.modules.setdefault("botocore", botocore_stub)
+sys.modules.setdefault("botocore.exceptions", botocore_exceptions_stub)
+
+from src.armory.python_tools import DatasetTools
+from src.utils.config_types import DuckContext
+from src.utils.protocols import ConcludesResponse
+
+
+class _FakeContainer:
+    def __init__(self, inventory):
+        self._inventory = inventory
+
+    def get_dataset_inventory(self):
+        return self._inventory
+
+
+def _ctx(thread_id=999) -> DuckContext:
+    return DuckContext(
+        guild_id=1,
+        parent_channel_id=2,
+        author_id=3,
+        author_mention="@user",
+        content="list datasets",
+        message_id=4,
+        thread_id=thread_id,
+        timeout=60,
+    )
+
+
+def test_send_datasets_to_user_sorts_dedupes_and_falls_back_to_filename():
+    sent_messages = []
+
+    async def _send_message(_channel_id, message=None, file=None, view=None):
+        if message is not None:
+            sent_messages.append(message)
+        return 1
+
+    containers = [
+        _FakeContainer(
+            [
+                {"dataset_name": "zeta", "filename": "zeta.csv", "path": "/d/zeta.csv"},
+                {"dataset_name": "Alpha", "filename": "alpha.csv", "path": "/d/alpha.csv"},
+                {"filename": "fallback.csv", "path": "/d/fallback.csv"},
+            ]
+        ),
+        _FakeContainer(
+            [
+                {"dataset_name": "Alpha", "filename": "alpha-2.csv", "path": "/d/alpha-2.csv"},
+                {"dataset_name": "beta", "filename": "beta.csv", "path": "/d/beta.csv"},
+            ]
+        ),
+    ]
+    tools = DatasetTools(containers, _send_message)
+
+    result = asyncio.run(tools.send_datasets_to_user(_ctx()))
+
+    assert isinstance(result, ConcludesResponse)
+    assert result.result == "Sent 4 dataset names."
+    assert len(sent_messages) == 1
+    assert sent_messages[0] == "\n".join(
+        [
+            "Available datasets:",
+            "- Alpha",
+            "- beta",
+            "- fallback.csv",
+            "- zeta",
+        ]
+    )
+
+
+def test_send_datasets_to_user_sends_full_large_list():
+    sent_messages = []
+
+    async def _send_message(_channel_id, message=None, file=None, view=None):
+        if message is not None:
+            sent_messages.append(message)
+        return 1
+
+    inventory = [
+        {"dataset_name": f"Dataset {i:03d}", "filename": f"dataset_{i:03d}.csv", "path": "/d/x.csv"}
+        for i in range(220)
+    ]
+    tools = DatasetTools([_FakeContainer(inventory)], _send_message)
+
+    result = asyncio.run(tools.send_datasets_to_user(_ctx()))
+
+    assert isinstance(result, ConcludesResponse)
+    assert len(sent_messages) == 1
+    rendered = sent_messages[0]
+    assert "- Dataset 000" in rendered
+    assert "- Dataset 219" in rendered
+
+
+def test_send_datasets_to_user_reports_empty_inventory():
+    sent_messages = []
+
+    async def _send_message(_channel_id, message=None, file=None, view=None):
+        if message is not None:
+            sent_messages.append(message)
+        return 1
+
+    tools = DatasetTools([_FakeContainer([])], _send_message)
+
+    result = asyncio.run(tools.send_datasets_to_user(_ctx()))
+
+    assert isinstance(result, ConcludesResponse)
+    assert result.result == "No datasets are currently available."
+    assert sent_messages == ["No datasets are currently available."]


### PR DESCRIPTION
  - Updates stats.md guidance using Jessica's suggestions (scope, categorical regression/prediction rules, etc.)
  - Make describe_dataset more efficient
       - the agent was consistently calling it with the full path instead of filename, so I made both work
  - Aligns tool description text in src/main.py
  - Fixed wacky issues when listing available datasets
      - Added a tool to send them directly to the user
      - Listing all datasets before performing operations does not improve behavior anymore
          - I fixed this in my last change when I created the `describe_dataset` tool
  - Adds April 10, 2026 meeting notes