### PR TITLE
Discord 503 error handling

### DIFF
--- a/src/gen_ai/gen_ai.py
+++ b/src/gen_ai/gen_ai.py
@@ -1,4 +1,3 @@
-import asyncio
 import inspect
 import json
 import os
@@ -16,6 +15,7 @@ from ..armory.armory import Armory
 from ..armory.talk_tool import ConversationComplete
 from ..utils.config_types import DuckContext, HistoryType, RetryProtocol
 from ..utils.logger import duck_logger
+from ..utils.retry import retry_async, retry_delay_seconds, is_retryable_discord_server_error
 
 
 class GenAIException(Exception):
@@ -93,22 +93,13 @@ class AIClient:
             return True
         return payload.get("code") == "server_is_overloaded"
 
-    @staticmethod
-    def _is_retryable_discord_server_error(error: Exception) -> bool:
-        return (
-            error.__class__.__name__ == "DiscordServerError" and
-            getattr(error, "status", None) == 503
-        )
-
     def _should_retry(self, error: Exception) -> bool:
         if isinstance(error, InternalServerError):
             return self._is_retryable_server_overload(error)
-        return self._is_retryable_discord_server_error(error)
+        return is_retryable_discord_server_error(error)
 
     def _retry_delay_seconds(self, attempt: int) -> int:
-        base_delay = max(0, int(self._retry_protocol.get("delay", 0)))
-        backoff = max(1, int(self._retry_protocol.get("backoff", 1)))
-        return base_delay * (backoff ** attempt)
+        return retry_delay_seconds(self._retry_protocol, attempt)
 
     async def _notify_retry(self, ctx: DuckContext, delay_seconds: int):
         if not self._send_message:
@@ -149,22 +140,19 @@ class AIClient:
         if reasoning:
             params["reasoning"] = {"effort": reasoning}
 
-        max_retries = max(0, int(self._retry_protocol.get("max_retries", 0)))
-        for attempt in range(max_retries + 1):
-            try:
-                async with self._typing(ctx.thread_id):
-                    response = await self._client.responses.create(**params)
-                break
-            except Exception as error:
-                should_retry = (
-                    attempt < max_retries and
-                    self._should_retry(error)
-                )
-                if not should_retry:
-                    raise
-                delay_seconds = self._retry_delay_seconds(attempt)
-                await self._notify_retry(ctx, delay_seconds)
-                await asyncio.sleep(delay_seconds)
+        async def create_completion():
+            async with self._typing(ctx.thread_id):
+                return await self._client.responses.create(**params)
+
+        async def on_retry(_error: Exception, attempt: int, _delay_seconds: int):
+            await self._notify_retry(ctx, self._retry_delay_seconds(attempt))
+
+        response = await retry_async(
+            create_completion,
+            self._retry_protocol,
+            self._should_retry,
+            on_retry
+        )
 
         if response.usage:
             usage = response.usage

--- a/src/main.py
+++ b/src/main.py
@@ -104,7 +104,8 @@ def build_registration_duck(
         bot.get_channel,
         bot.fetch_guild,
         email_confirmation,
-        settings
+        settings,
+        config["ai_completion_retry_protocol"]
     )
     armory.scrub_tools(registration)
     registration_workflow = RegistrationWorkflow(name, registration, registration_bot)

--- a/src/utils/retry.py
+++ b/src/utils/retry.py
@@ -1,0 +1,53 @@
+import asyncio
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+from .config_types import RetryProtocol
+
+T = TypeVar("T")
+
+
+def retry_delay_seconds(retry_protocol: RetryProtocol, attempt: int) -> int:
+    base_delay = max(0, int(retry_protocol.get("delay", 0)))
+    backoff = max(1, int(retry_protocol.get("backoff", 1)))
+    return base_delay * (backoff ** attempt)
+
+
+def is_retryable_discord_server_error(error: Exception) -> bool:
+    return (
+        error.__class__.__name__ == "DiscordServerError" and
+        getattr(error, "status", None) == 503
+    )
+
+
+async def retry_async(
+        operation: Callable[[], Awaitable[T]],
+        retry_protocol: RetryProtocol,
+        should_retry: Callable[[Exception], bool],
+        on_retry: Callable[[Exception, int, int], Awaitable[None]] | None = None,
+        on_exhausted: Callable[[Exception, int], Awaitable[None]] | None = None,
+) -> T:
+    max_retries = max(0, int(retry_protocol.get("max_retries", 0)))
+
+    for attempt in range(max_retries + 1):
+        try:
+            return await operation()
+        except Exception as error:
+            if should_retry(error) and attempt == max_retries:
+                if on_exhausted:
+                    await on_exhausted(error, attempt)
+                raise
+
+            should_retry_error = (
+                attempt < max_retries and
+                should_retry(error)
+            )
+            if not should_retry_error:
+                raise
+
+            delay_seconds = retry_delay_seconds(retry_protocol, attempt)
+            if on_retry:
+                await on_retry(error, attempt, delay_seconds)
+            await asyncio.sleep(delay_seconds)
+
+    raise RuntimeError("Retry loop exited unexpectedly.")

--- a/src/workflows/registration.py
+++ b/src/workflows/registration.py
@@ -7,10 +7,11 @@ from discord import Guild, utils
 from quest import step
 
 from ..armory.tools import register_tool
-from ..utils.config_types import RegistrationSettings, DuckContext
+from ..utils.config_types import RegistrationSettings, DuckContext, RetryProtocol
 from ..utils.logger import duck_logger
 from ..utils.message_utils import wait_for_message
 from ..utils.protocols import ConversationComplete
+from ..utils.retry import retry_async, is_retryable_discord_server_error
 from ..utils.send_email import EmailSender
 
 
@@ -37,13 +38,45 @@ class Registration:
                  get_channel,
                  fetch_guild,
                  email_sender: EmailSender,
-                 settings: RegistrationSettings
+                 settings: RegistrationSettings,
+                 retry_protocol: RetryProtocol,
                  ):
         self._send_message = step(send_message)
         self._get_channel = get_channel
         self._get_guild = fetch_guild
         self._email_sender = email_sender
         self._settings = settings
+        self._retry_protocol = retry_protocol
+
+    async def _handle_discord_retry_exhausted(self, ctx: DuckContext, operation_name: str, error: Exception):
+        duck_logger.warning(
+            "Discord connection issue persisted after retries during registration "
+            f"({operation_name}) in thread <#{ctx.thread_id}>: {error}"
+        )
+
+        await self._send_message(
+            ctx.thread_id,
+            "I'm having temporary connection issues with Discord right now. "
+            "Please try again later. I've notified a TA."
+        )
+
+        ta_channel_id = self._settings.get('ta_channel_id')
+        if ta_channel_id:
+            await self._send_message(
+                ta_channel_id,
+                "Registration hit repeated Discord connection issues "
+                f"during `{operation_name}` in thread <#{ctx.thread_id}> for user <@{ctx.author_id}>."
+            )
+
+        raise ConversationComplete()
+
+    async def _retry_discord_call(self, ctx: DuckContext, operation_name: str, operation):
+        return await retry_async(
+            operation,
+            self._retry_protocol,
+            is_retryable_discord_server_error,
+            on_exhausted=lambda error, _attempt: self._handle_discord_retry_exhausted(ctx, operation_name, error)
+        )
 
     async def run(self, ctx: DuckContext) -> RegistrationInfo | None:
         # Start the registration process
@@ -270,7 +303,7 @@ class Registration:
             duck_logger.info("No roles configured for this server. Using authenticated user role only.")
             role_name = settings['authenticated_user_role_name']
             guild: Guild = await self._get_guild(server_id)
-            member = await guild.fetch_member(user_id)
+            member = await self._retry_discord_call(ctx, "fetch_member", lambda: guild.fetch_member(user_id))
 
             # Find role by name instead of ID
             role = utils.get(guild.roles, name=role_name)  # This function is from the discord.utils module
@@ -280,7 +313,11 @@ class Registration:
             selected_roles = [role]
             role_names = ", ".join(role.name for role in selected_roles)
             try:
-                await member.add_roles(role, reason="User registration")
+                await self._retry_discord_call(
+                    ctx,
+                    "add_roles",
+                    lambda: member.add_roles(role, reason="User registration")
+                )
             except discord.Forbidden:
                 await self._send_message(
                     self._settings['ta_channel_id'],
@@ -301,7 +338,7 @@ class Registration:
 
             # Get Discord guild and member
             guild: Guild = await self._get_guild(server_id)
-            member = await guild.fetch_member(user_id)
+            member = await self._retry_discord_call(ctx, "fetch_member", lambda: guild.fetch_member(user_id))
 
             # Get member's current roles
             current_role_ids = await self.get_user_roles(member)
@@ -326,7 +363,11 @@ class Registration:
             new_roles = [role for role in selected_roles if role not in member.roles]
             if new_roles:
                 try:
-                    await member.add_roles(*new_roles, reason="User registration")
+                    await self._retry_discord_call(
+                        ctx,
+                        "add_roles",
+                        lambda: member.add_roles(*new_roles, reason="User registration")
+                    )
                 except discord.Forbidden:
                     duck_logger.exception(f"Failed to assign roles: {new_roles} to user in thread: <#{thread_id}>")
                     await self._send_message(
@@ -375,7 +416,7 @@ class Registration:
         """Try assigning the nickname, return (success, reason)."""
         try:
             guild: Guild = await self._get_guild(ctx.guild_id)
-            member = await guild.fetch_member(ctx.author_id)
+            member = await self._retry_discord_call(ctx, "fetch_member", lambda: guild.fetch_member(ctx.author_id))
 
             suspicious, reason = await self._is_suspicious(name)
             if suspicious:
@@ -384,7 +425,11 @@ class Registration:
             if member.guild.owner_id == member.id:
                 return False, "Cannot change the server owner's nickname"
 
-            await member.edit(nick=name, reason="Student registration")
+            await self._retry_discord_call(
+                ctx,
+                "edit_nickname",
+                lambda: member.edit(nick=name, reason="Student registration")
+            )
             return True, "Nickname set successfully"
         except discord.Forbidden:
             await self._send_message(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,9 +7,69 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+boto3_stub = types.ModuleType("boto3")
+boto3_stub.client = lambda *_args, **_kwargs: types.SimpleNamespace()
+sys.modules.setdefault("boto3", boto3_stub)
+
+botocore_stub = types.ModuleType("botocore")
+botocore_exceptions_stub = types.ModuleType("botocore.exceptions")
+
+
+class _ClientError(Exception):
+    pass
+
+
+botocore_exceptions_stub.ClientError = _ClientError
+botocore_stub.exceptions = botocore_exceptions_stub
+sys.modules.setdefault("botocore", botocore_stub)
+sys.modules.setdefault("botocore.exceptions", botocore_exceptions_stub)
+
+try:
+    import discord  # noqa: F401
+except ModuleNotFoundError:
+    discord_stub = types.ModuleType("discord")
+
+    class _Forbidden(Exception):
+        pass
+
+    class _Guild:
+        pass
+
+    class _Member:
+        pass
+
+    class _Utils:
+        @staticmethod
+        def get(iterable, **attrs):
+            for item in iterable:
+                if all(getattr(item, key, None) == value for key, value in attrs.items()):
+                    return item
+            return None
+
+    discord_stub.Forbidden = _Forbidden
+    discord_stub.Guild = _Guild
+    discord_stub.Member = _Member
+    discord_stub.utils = _Utils()
+    sys.modules.setdefault("discord", discord_stub)
+
 quest_mod = types.ModuleType("quest")
 quest_utils_mod = types.ModuleType("quest.utils")
 quest_utils_mod.quest_logger = logging.getLogger("quest")
+quest_mod.step = lambda fn: fn
+
+
+class _QueueStub:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+    async def get(self):
+        return None
+
+
+quest_mod.queue = lambda *_args, **_kwargs: _QueueStub()
 quest_mod.utils = quest_utils_mod
 sys.modules.setdefault("quest", quest_mod)
 sys.modules.setdefault("quest.utils", quest_utils_mod)

--- a/tests/test_retry_paths.py
+++ b/tests/test_retry_paths.py
@@ -1,0 +1,239 @@
+import asyncio
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from src.gen_ai.gen_ai import AIClient
+from src.utils.config_types import DuckContext
+from src.utils.protocols import ConversationComplete
+from src.workflows.registration import Registration
+
+
+class DiscordServerError(Exception):
+    def __init__(self, status=503):
+        self.status = status
+        super().__init__("503 Service Unavailable")
+
+
+class _FakeOutput:
+    def model_dump(self, exclude_none=True):
+        return {"type": "message", "content": "ok"}
+
+
+class _FakeResponse:
+    def __init__(self):
+        self.output = [_FakeOutput()]
+        self.usage = None
+
+
+class _Typing:
+    async def __aenter__(self):
+        return None
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        return None
+
+
+def _ctx(thread_id=999) -> DuckContext:
+    return DuckContext(
+        guild_id=1,
+        parent_channel_id=2,
+        author_id=3,
+        author_mention="@user",
+        content="hello",
+        message_id=4,
+        thread_id=thread_id,
+        timeout=60,
+    )
+
+
+def test_gen_ai_retries_discord_server_error():
+    os.environ.setdefault("OPENAI_API_KEY", "test-key")
+
+    sent_messages = []
+    attempts = {"count": 0}
+
+    async def _record_message(*_args, **_kwargs):
+        return None
+
+    async def _record_usage(*_args, **_kwargs):
+        return None
+
+    async def _send_message(_channel_id, message=None, file=None, view=None):
+        if message is not None:
+            sent_messages.append(message)
+        return 1
+
+    def _typing(_thread_id):
+        return _Typing()
+
+    client = AIClient(
+        armory=None,
+        typing=_typing,
+        record_message=_record_message,
+        record_usage=_record_usage,
+        retry_protocol={"max_retries": 2, "delay": 0, "backoff": 1},
+        send_message=_send_message,
+    )
+
+    async def _create(**_params):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise DiscordServerError()
+        return _FakeResponse()
+
+    client._client = SimpleNamespace(
+        responses=SimpleNamespace(create=_create)
+    )
+
+    result = asyncio.run(
+        client._get_completion(
+            _ctx(),
+            prompt="prompt",
+            local_history=[],
+            context=[],
+            model="gpt-test",
+            tools=[],
+            tool_settings="auto",
+            output_format=None,
+        )
+    )
+
+    assert attempts["count"] == 2
+    assert result == [{"type": "message", "content": "ok"}]
+    assert sent_messages == ["I hit a temporary connection issue with an upstream server. Retrying in 0 seconds..."]
+
+
+def test_registration_retries_discord_server_error_during_fetch_member():
+    sent_messages = []
+    fetch_attempts = {"count": 0}
+
+    async def _send_message(_channel_id, message=None, file=None, view=None):
+        if message is not None:
+            sent_messages.append(message)
+        return 1
+
+    async def _fetch_guild(_guild_id):
+        return guild
+
+    class _EmailSender:
+        def send_email(self, *_args, **_kwargs):
+            return "123456"
+
+    class _Role:
+        def __init__(self, role_id, name):
+            self.id = role_id
+            self.name = name
+
+    class _Member:
+        def __init__(self):
+            self.roles = []
+
+        async def add_roles(self, *roles, reason=None):
+            self.roles.extend(roles)
+
+    class _Guild:
+        def __init__(self):
+            self.name = "Test Guild"
+            self.roles = [_Role(10, "Authenticated")]
+
+        async def fetch_member(self, _user_id):
+            fetch_attempts["count"] += 1
+            if fetch_attempts["count"] == 1:
+                raise DiscordServerError()
+            return member
+
+    member = _Member()
+    guild = _Guild()
+
+    registration = Registration(
+        _send_message,
+        get_channel=lambda *_args, **_kwargs: None,
+        fetch_guild=_fetch_guild,
+        email_sender=_EmailSender(),
+        settings={
+            "cache_timeout": 60,
+            "authenticated_user_role_name": "Authenticated",
+            "email_domain": "example.edu",
+            "roles": None,
+            "registration_bot": "registration-bot",
+            "ta_channel_id": 123,
+        },
+        retry_protocol={"max_retries": 2, "delay": 0, "backoff": 1},
+    )
+
+    result = asyncio.run(registration.assign_roles(_ctx()))
+
+    assert fetch_attempts["count"] == 2
+    assert result == "Authenticated"
+    assert sent_messages == ["Successfully gave you the following roles: Authenticated"]
+
+
+def test_registration_exhausted_discord_retry_notifies_user_and_ta(caplog):
+    sent_messages = []
+    fetch_attempts = {"count": 0}
+
+    async def _send_message(channel_id, message=None, file=None, view=None):
+        if message is not None:
+            sent_messages.append((channel_id, message))
+        return 1
+
+    async def _fetch_guild(_guild_id):
+        return guild
+
+    class _EmailSender:
+        def send_email(self, *_args, **_kwargs):
+            return "123456"
+
+    class _Role:
+        def __init__(self, role_id, name):
+            self.id = role_id
+            self.name = name
+
+    class _Guild:
+        def __init__(self):
+            self.name = "Test Guild"
+            self.roles = [_Role(10, "Authenticated")]
+
+        async def fetch_member(self, _user_id):
+            fetch_attempts["count"] += 1
+            raise DiscordServerError()
+
+    guild = _Guild()
+    ctx = _ctx(thread_id=456)
+
+    registration = Registration(
+        _send_message,
+        get_channel=lambda *_args, **_kwargs: None,
+        fetch_guild=_fetch_guild,
+        email_sender=_EmailSender(),
+        settings={
+            "cache_timeout": 60,
+            "authenticated_user_role_name": "Authenticated",
+            "email_domain": "example.edu",
+            "roles": None,
+            "registration_bot": "registration-bot",
+            "ta_channel_id": 123,
+        },
+        retry_protocol={"max_retries": 2, "delay": 0, "backoff": 1},
+    )
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(ConversationComplete):
+            asyncio.run(registration.assign_roles(ctx))
+
+    assert fetch_attempts["count"] == 3
+    assert sent_messages == [
+        (
+            456,
+            "I'm having temporary connection issues with Discord right now. "
+            "Please try again later. I've notified a TA."
+        ),
+        (
+            123,
+            "Registration hit repeated Discord connection issues "
+            "during `fetch_member` in thread <#456> for user <@3>."
+        ),
+    ]
+    assert "Discord connection issue persisted after retries during registration" in caplog.text


### PR DESCRIPTION
# Overview
- This is the same error as before, but my fix only applied the retry process in gen_ai, not within the registration workflow.
- I separated out the retry logic for both and put it in utils so they can both use the same retry logic

## Summary/Purpose: 
Centralize retry handling for transient Discord 503s and make registration fail more cleanly after repeated upstream connection issues.

## Black-box changes:
  - Registration now retries transient Discord-side 503 failures on member lookup, role assignment, and nickname edits.
  - If those retries are exhausted, the user is told Discord is having connection issues and to try again later.
  - If configured, the TA channel is notified when registration gives up after repeated Discord connection failures.
  - Existing gen_ai retry behavior is preserved, but now uses the shared retry helper.
  - Added tests that force retryable Discord errors in both gen_ai and registration paths.
 
## File-by-file changes:
  - src/utils/retry.py: Added shared async retry utility, shared Discord 503 predicate, and exhausted-retry hook.
  - src/gen_ai/gen_ai.py: Replaced local retry loop with shared retry helper.
  - src/workflows/registration.py: Applied shared retry helper to Discord member operations and added exhausted-retry user/TA/log handling.
  - src/main.py: Passed retry protocol config into registration.
  - tests/test_retry_paths.py: Added forced-error tests for gen_ai retry success, registration retry success, and registration exhausted-retry notifications.
  - tests/conftest.py: Expanded test stubs so retry-path tests can run in the local test environment.