### PR TITLE
correction for keyerror under IS role

### DIFF
--- a/production-config.yaml
+++ b/production-config.yaml
@@ -266,7 +266,7 @@ servers:
                     pattern: "-section-"
                     description: Sorted by teacher's name (e.g. smith-section-000)
                   Independent Study:
-                    patter: "independent-study"
+                    pattern: "independent-study"
                     description: For students enrolled in the BYU-IS program
 
   CS Faculty:


### PR DESCRIPTION
Independent study registrations breaks off the production config's use of 'patter' instead of 'pattern'. Change made to catch this break condition.